### PR TITLE
chore: bump MSRV to 1.92, fix dependabot dtolnay/rust-toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
     commit-message:
       prefix: "ci(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.100
+      - uses: dtolnay/rust-toolchain@1.92
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
       - name: Test (all features)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "structured-email-address"
 version = "0.0.1"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.92"
 authors = ["Structured World Foundation <foundation@sw.foundation>"]
 description = "RFC 5321/5322/6531 email address parser, validator, and normalizer. Subaddress extraction, provider-aware normalization, PSL domain validation, anti-homoglyph protection."
 documentation = "https://docs.rs/structured-email-address/"


### PR DESCRIPTION
## Summary
- Bump `rust-version` in Cargo.toml: 1.85 → 1.92
- Fix MSRV CI job: `@1.100` (non-existent Rust) → `@1.92`
- Exclude `dtolnay/rust-toolchain` from dependabot github-actions updates

## Why
`dtolnay/rust-toolchain` creates skeleton branches for future Rust versions. Dependabot sees `1.100 > 1.85` and proposes an "update" to a Rust version that doesn't exist yet (latest stable is 1.94). This broke the MSRV CI job.

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported Rust version to 1.92 (from 1.85)
  * Configured CI toolchain version for consistent testing
  * Updated dependency management to exclude automatic toolchain action updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->