### PR TITLE
docs: add IDN homograph safety note to domain_unicode()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,18 @@ impl EmailAddress {
     /// returns the Unicode form of the canonical domain. For ASCII-only
     /// domains, returns the same value as [`domain()`](Self::domain).
     ///
+    /// # Security
+    ///
+    /// The Unicode form is intended for **display only**. It may reintroduce
+    /// [IDN homograph attacks](https://en.wikipedia.org/wiki/IDN_homograph_attack)
+    /// where visually similar characters from different scripts produce
+    /// different domain names (e.g. Cyrillic `а` vs Latin `a`).
+    ///
+    /// For security-sensitive comparisons (allow-lists, deduplication, access
+    /// control), always use [`domain()`](Self::domain) which returns the
+    /// ACE/Punycode form. If you must compare Unicode domains, apply your own
+    /// confusable-detection logic (see [`confusable_skeleton()`]).
+    ///
     /// ```
     /// use structured_email_address::EmailAddress;
     ///


### PR DESCRIPTION
## Summary

- Add a `# Security` section to `domain_unicode()` doc comment warning about IDN homograph attack risk
- Recommend `domain()` (ACE/Punycode) for security-sensitive comparisons
- Point to `confusable_skeleton()` for Unicode-level spoof detection

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security guidance for email domain operations, providing best practices for handling internationalized domain names and recommendations for security-critical use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->