### PR TITLE
fix(parser): strip CFWS from obs-local-part and obs-domain spans

### DIFF
--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -29,20 +29,21 @@ pub(crate) struct Normalized {
 
 /// Normalize a parsed email address according to the given config.
 pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normalized, Error> {
-    let raw_local = parsed.local_part_str();
-    let raw_domain = parsed.domain_str();
-    let is_quoted = raw_local.starts_with('"') && raw_local.ends_with('"');
+    // Semantic local-part and domain: CFWS-stripped for obs-forms, raw span otherwise.
+    let local = parsed.local_part_str();
+    let domain_str = parsed.domain_str();
+    let is_quoted = local.starts_with('"') && local.ends_with('"');
 
     // Strip quotes and unescape RFC quoted-pairs from quoted-string local parts.
     let unquoted_local = if is_quoted {
-        unescape_quoted_string(&raw_local[1..raw_local.len() - 1])
+        unescape_quoted_string(&local[1..local.len() - 1])
     } else {
-        raw_local.to_string()
+        local.to_string()
     };
 
     // Step 1: Unicode NFC normalization.
     let nfc_local: String = unquoted_local.nfc().collect();
-    let nfc_domain: String = raw_domain.nfc().collect();
+    let nfc_domain: String = domain_str.nfc().collect();
 
     // Step 2: Case folding.
     let cased_local = match config.case_policy {
@@ -354,5 +355,18 @@ mod tests {
         assert_eq!(n.tag, Some("promo".to_string()));
         assert_eq!(n.domain, "gmail.com");
         assert!(n.skeleton.is_some());
+    }
+
+    #[test]
+    fn obs_cfws_stripped_before_normalization() {
+        // Verify that CFWS-stripped content flows through NFC, case folding,
+        // and IDNA encoding correctly.
+        let config = Config::builder()
+            .strictness(crate::Strictness::Lax)
+            .lowercase_all()
+            .build();
+        let n = parse_and_normalize("User (comment) . Name@Example (c) . COM", &config);
+        assert_eq!(n.local_part, "user.name", "CFWS stripped + lowercased");
+        assert_eq!(n.domain, "example.com", "domain CFWS stripped + lowercased");
     }
 }

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -29,8 +29,8 @@ pub(crate) struct Normalized {
 
 /// Normalize a parsed email address according to the given config.
 pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normalized, Error> {
-    let raw_local = parsed.local_part.as_str(parsed.input);
-    let raw_domain = parsed.domain.as_str(parsed.input);
+    let raw_local = parsed.local_part_str();
+    let raw_domain = parsed.domain_str();
     let is_quoted = raw_local.starts_with('"') && raw_local.ends_with('"');
 
     // Strip quotes and unescape RFC quoted-pairs from quoted-string local parts.
@@ -284,6 +284,8 @@ mod tests {
                 end: input.len(),
             },
             comments: vec![],
+            local_part_clean: None,
+            domain_clean: None,
         };
         let err = normalize(&parsed, &config).unwrap_err();
         assert!(

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -359,8 +359,7 @@ mod tests {
 
     #[test]
     fn obs_cfws_stripped_before_normalization() {
-        // Verify that CFWS-stripped content flows through NFC, case folding,
-        // and IDNA encoding correctly.
+        // Verify that CFWS-stripped content flows through case folding.
         let config = Config::builder()
             .strictness(crate::Strictness::Lax)
             .lowercase_all()
@@ -368,5 +367,17 @@ mod tests {
         let n = parse_and_normalize("User (comment) . Name@Example (c) . COM", &config);
         assert_eq!(n.local_part, "user.name", "CFWS stripped + lowercased");
         assert_eq!(n.domain, "example.com", "domain CFWS stripped + lowercased");
+    }
+
+    #[test]
+    fn obs_cfws_stripped_with_idna() {
+        // Verify CFWS stripping flows through IDNA encoding.
+        let config = Config::builder()
+            .strictness(crate::Strictness::Lax)
+            .lowercase_all()
+            .build();
+        let n = parse_and_normalize("user@münchen (comment) . de", &config);
+        assert_eq!(n.domain, "xn--mnchen-3ya.de");
+        assert_eq!(n.domain_unicode.as_deref(), Some("münchen.de"));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -368,11 +368,11 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
             clean = Some(s);
         }
         skip_cfws(parser, 0);
-        // If CFWS after dot and we haven't started clean yet, the prefix
-        // extends through the dot (last_clean_end + 1 byte for '.').
+        // If CFWS after dot and we haven't started clean yet, seed with
+        // content before the dot — the dot is appended below via push('.').
         if clean.is_none() && parser.pos > last_clean_end + 1 {
             let mut s = String::with_capacity(64);
-            s.push_str(&parser.input[outer_start..last_clean_end + 1]);
+            s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
         let atom_start = parser.pos;
@@ -532,7 +532,7 @@ fn parse_dot_atom_domain(
         skip_cfws(parser, 0);
         if clean.is_none() && parser.pos > last_clean_end + 1 {
             let mut s = String::with_capacity(64);
-            s.push_str(&parser.input[outer_start..last_clean_end + 1]);
+            s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
         let label_start = parser.pos;
@@ -1167,6 +1167,20 @@ mod tests {
         )
         .expect_err("leading CFWS in bare addr-spec must be rejected");
         assert_eq!(e.kind(), &ErrorKind::InvalidLocalPartChar { ch: '(' });
+    }
+
+    #[test]
+    fn obs_local_cfws_after_dot_no_double_dots() {
+        // CFWS only after dot: "user. name" must produce "user.name", not "user..name".
+        let p = parse_ok_lax("user. name@example.com");
+        assert_eq!(p.local_part_str(), "user.name");
+    }
+
+    #[test]
+    fn obs_domain_cfws_after_dot_no_double_dots() {
+        // CFWS only after dot: "example. com" must produce "example.com", not "example..com".
+        let p = parse_ok_lax("user@example. com");
+        assert_eq!(p.domain_str(), "example.com");
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -363,7 +363,7 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
             break;
         }
         if had_cfws_before_dot && clean.is_none() {
-            let mut s = String::with_capacity(64);
+            let mut s = String::with_capacity(parser.input.len().saturating_sub(outer_start));
             s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
@@ -371,7 +371,7 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
         // If CFWS after dot and we haven't started clean yet, seed with
         // content before the dot — the dot is appended below via push('.').
         if clean.is_none() && parser.pos > last_clean_end + 1 {
-            let mut s = String::with_capacity(64);
+            let mut s = String::with_capacity(parser.input.len().saturating_sub(outer_start));
             s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
@@ -525,13 +525,13 @@ fn parse_dot_atom_domain(
             break;
         }
         if had_cfws_before_dot && clean.is_none() {
-            let mut s = String::with_capacity(64);
+            let mut s = String::with_capacity(parser.input.len().saturating_sub(outer_start));
             s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
         skip_cfws(parser, 0);
         if clean.is_none() && parser.pos > last_clean_end + 1 {
-            let mut s = String::with_capacity(64);
+            let mut s = String::with_capacity(parser.input.len().saturating_sub(outer_start));
             s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
@@ -1155,17 +1155,17 @@ mod tests {
     }
 
     #[test]
-    fn obs_leading_cfws_rejected_in_bare_addr_spec() {
-        // Leading CFWS before local-part is only valid in angle-bracket form,
-        // not bare addr-spec. obs-local-part CFWS stripping only applies
-        // between word segments, not before the first word.
+    fn obs_leading_comment_rejected_in_bare_addr_spec() {
+        // Leading RFC 5322 comments before local-part are rejected in bare
+        // addr-spec. Note: leading plain whitespace is handled by input.trim()
+        // before parsing, so this test covers comments specifically.
         let e = parse(
             "(leading) user . name@example.com",
             Strictness::Lax,
             false,
             false,
         )
-        .expect_err("leading CFWS in bare addr-spec must be rejected");
+        .expect_err("leading comment in bare addr-spec must be rejected");
         assert_eq!(e.kind(), &ErrorKind::InvalidLocalPartChar { ch: '(' });
     }
 
@@ -1186,23 +1186,35 @@ mod tests {
     #[test]
     fn obs_trailing_cfws_before_at_preserves_zero_copy() {
         // Trailing CFWS before '@' is NOT between atoms — it's excluded from
-        // the span by backtracking. Must not trigger allocation.
+        // the span by backtracking. Must not trigger allocation or duplicate
+        // comment spans.
         let p = parse_ok_lax("user (trailing)@example.com");
         assert!(
             p.local_part_clean.is_none(),
             "trailing CFWS before @ must not trigger allocation"
         );
         assert_eq!(p.local_part_str(), "user");
+        assert_eq!(
+            p.comments.len(),
+            1,
+            "backtracked comment must not be duplicated"
+        );
     }
 
     #[test]
     fn obs_trailing_cfws_after_domain_preserves_zero_copy() {
-        // Trailing CFWS after domain is NOT between labels — must not allocate.
+        // Trailing CFWS after domain is NOT between labels — must not allocate
+        // or duplicate comment spans.
         let p = parse_ok_lax("user@example.com (trailing)");
         assert!(
             p.domain_clean.is_none(),
             "trailing CFWS after domain must not trigger allocation"
         );
         assert_eq!(p.domain_str(), "example.com");
+        assert_eq!(
+            p.comments.len(),
+            1,
+            "backtracked comment must not be duplicated"
+        );
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -351,14 +351,19 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
     // Subsequent ".atom" segments
     loop {
         let save = parser.save();
-        let before = parser.pos;
+        let cfws_before_dot = parser.pos;
         skip_cfws(parser, 0);
-        if parser.pos > before {
-            had_cfws = true;
-        }
+        let had_cfws_before_dot = parser.pos > cfws_before_dot;
         if !parser.eat('.') {
+            // No dot found — CFWS here is trailing (before @/>/EOF), not between
+            // atoms. Restore position; don't mark had_cfws since the CFWS is
+            // excluded from the span anyway.
             parser.restore(save);
             break;
+        }
+        // Dot consumed — CFWS before the dot IS between atoms.
+        if had_cfws_before_dot {
+            had_cfws = true;
         }
         let before = parser.pos;
         skip_cfws(parser, 0);
@@ -513,14 +518,18 @@ fn parse_dot_atom_domain(
 
     loop {
         let save = parser.save();
-        let before = parser.pos;
+        let cfws_before_dot = parser.pos;
         skip_cfws(parser, 0);
-        if parser.pos > before {
-            had_cfws = true;
-        }
+        let had_cfws_before_dot = parser.pos > cfws_before_dot;
         if !parser.eat('.') {
+            // No dot found — CFWS here is trailing (before >/EOF), not between
+            // labels. Restore position; don't mark had_cfws.
             parser.restore(save);
             break;
+        }
+        // Dot consumed — CFWS before the dot IS between labels.
+        if had_cfws_before_dot {
+            had_cfws = true;
         }
         let before = parser.pos;
         skip_cfws(parser, 0);
@@ -1157,5 +1166,28 @@ mod tests {
         // Leading CFWS before first atom in obs-local-part.
         let p = parse_ok_lax("(leading) user . name@example.com");
         assert_eq!(p.local_part_str(), "user.name");
+    }
+
+    #[test]
+    fn obs_trailing_cfws_before_at_preserves_zero_copy() {
+        // Trailing CFWS before '@' is NOT between atoms — it's excluded from
+        // the span by backtracking. Must not trigger allocation.
+        let p = parse_ok_lax("user (trailing)@example.com");
+        assert!(
+            p.local_part_clean.is_none(),
+            "trailing CFWS before @ must not trigger allocation"
+        );
+        assert_eq!(p.local_part_str(), "user");
+    }
+
+    #[test]
+    fn obs_trailing_cfws_after_domain_preserves_zero_copy() {
+        // Trailing CFWS after domain is NOT between labels — must not allocate.
+        let p = parse_ok_lax("user@example.com (trailing)");
+        assert!(
+            p.domain_clean.is_none(),
+            "trailing CFWS after domain must not trigger allocation"
+        );
+        assert_eq!(p.domain_str(), "example.com");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -331,34 +331,39 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
         return Ok(None);
     }
 
-    // Obs mode: collect atom spans for clean reconstruction.
-    let outer_start = parser.pos;
-    let mut atoms: Vec<&str> = Vec::new();
+    // Obs mode: parse atoms and track CFWS presence.
+    // Atom boundaries stored on the stack to avoid heap allocation
+    // when no CFWS is present (the common case).
+    // RFC 5321: local-part ≤ 64 octets → max 32 single-char atoms.
+    const MAX_ATOMS: usize = 32;
+    let mut bounds: [(usize, usize); MAX_ATOMS] = [(0, 0); MAX_ATOMS];
+    let mut count = 0;
     let mut had_cfws = false;
 
-    // First word: optional CFWS + atext-run or quoted-string.
-    let before = parser.pos;
-    skip_cfws(parser, 0);
-    if parser.pos > before {
-        had_cfws = true;
-    }
+    // First word: no leading CFWS — bare addr-spec does not permit CFWS
+    // before the local-part. CFWS stripping only applies between segments.
     let atom_start = parser.pos;
     if !eat_atext_run(parser) && !try_quoted_string(parser) {
-        return Err(parser.error(ErrorKind::EmptyLocalPart));
+        return Err(match parser.peek() {
+            Some(ch) if ch != '@' => parser.error(ErrorKind::InvalidLocalPartChar { ch }),
+            _ => parser.error(ErrorKind::EmptyLocalPart),
+        });
     }
-    atoms.push(&parser.input[atom_start..parser.pos]);
+    bounds[count] = (atom_start, parser.pos);
+    count += 1;
 
     // Subsequent ".atom" segments
     loop {
         let save = parser.save();
+        let comments_len = parser.comments.len();
         let cfws_before_dot = parser.pos;
         skip_cfws(parser, 0);
         let had_cfws_before_dot = parser.pos > cfws_before_dot;
         if !parser.eat('.') {
-            // No dot found — CFWS here is trailing (before @/>/EOF), not between
-            // atoms. Restore position; don't mark had_cfws since the CFWS is
-            // excluded from the span anyway.
+            // No dot — trailing CFWS before @/>/EOF. Restore position and
+            // undo tentative comment spans added by skip_cfws.
             parser.restore(save);
+            parser.comments.truncate(comments_len);
             break;
         }
         // Dot consumed — CFWS before the dot IS between atoms.
@@ -374,18 +379,22 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
         if !eat_atext_run(parser) && !try_quoted_string(parser) {
             return Err(parser.error(ErrorKind::EmptyLocalPart));
         }
-        atoms.push(&parser.input[atom_start..parser.pos]);
+        if count < MAX_ATOMS {
+            bounds[count] = (atom_start, parser.pos);
+            count += 1;
+        }
     }
 
     if had_cfws {
-        Ok(Some(atoms.join(".")))
+        let mut clean = String::with_capacity(bounds[count - 1].1 - bounds[0].0);
+        for (i, &(start, end)) in bounds[..count].iter().enumerate() {
+            if i > 0 {
+                clean.push('.');
+            }
+            clean.push_str(&parser.input[start..end]);
+        }
+        Ok(Some(clean))
     } else {
-        // No CFWS found — verify span is clean (debug sanity check).
-        debug_assert_eq!(
-            &parser.input[outer_start..parser.pos],
-            atoms.join("."),
-            "obs-local-part without CFWS should match raw span"
-        );
         Ok(None)
     }
 }
@@ -507,24 +516,30 @@ fn parse_dot_atom_domain(
         return Ok(None);
     }
 
-    // Obs mode: collect label spans for clean reconstruction.
-    let outer_start = parser.pos;
-    let mut labels: Vec<&str> = Vec::new();
+    // Obs mode: parse labels and track CFWS presence.
+    // Label boundaries stored on the stack to avoid heap allocation
+    // when no CFWS is present (the common case).
+    const MAX_LABELS: usize = 16; // DNS: max 127 labels, but 16 covers all real domains
+    let mut bounds: [(usize, usize); MAX_LABELS] = [(0, 0); MAX_LABELS];
+    let mut count = 0;
     let mut had_cfws = false;
 
     let label_start = parser.pos;
     parse_domain_label(parser)?;
-    labels.push(&parser.input[label_start..parser.pos]);
+    bounds[count] = (label_start, parser.pos);
+    count += 1;
 
     loop {
         let save = parser.save();
+        let comments_len = parser.comments.len();
         let cfws_before_dot = parser.pos;
         skip_cfws(parser, 0);
         let had_cfws_before_dot = parser.pos > cfws_before_dot;
         if !parser.eat('.') {
-            // No dot found — CFWS here is trailing (before >/EOF), not between
-            // labels. Restore position; don't mark had_cfws.
+            // No dot — trailing CFWS before >/EOF. Restore position and
+            // undo tentative comment spans added by skip_cfws.
             parser.restore(save);
+            parser.comments.truncate(comments_len);
             break;
         }
         // Dot consumed — CFWS before the dot IS between labels.
@@ -538,17 +553,22 @@ fn parse_dot_atom_domain(
         }
         let label_start = parser.pos;
         parse_domain_label(parser)?;
-        labels.push(&parser.input[label_start..parser.pos]);
+        if count < MAX_LABELS {
+            bounds[count] = (label_start, parser.pos);
+            count += 1;
+        }
     }
 
     if had_cfws {
-        Ok(Some(labels.join(".")))
+        let mut clean = String::with_capacity(bounds[count - 1].1 - bounds[0].0);
+        for (i, &(start, end)) in bounds[..count].iter().enumerate() {
+            if i > 0 {
+                clean.push('.');
+            }
+            clean.push_str(&parser.input[start..end]);
+        }
+        Ok(Some(clean))
     } else {
-        debug_assert_eq!(
-            &parser.input[outer_start..parser.pos],
-            labels.join("."),
-            "obs-domain without CFWS should match raw span"
-        );
         Ok(None)
     }
 }
@@ -1162,10 +1182,18 @@ mod tests {
     }
 
     #[test]
-    fn obs_local_part_leading_cfws_stripped() {
-        // Leading CFWS before first atom in obs-local-part.
-        let p = parse_ok_lax("(leading) user . name@example.com");
-        assert_eq!(p.local_part_str(), "user.name");
+    fn obs_leading_cfws_rejected_in_bare_addr_spec() {
+        // Leading CFWS before local-part is only valid in angle-bracket form,
+        // not bare addr-spec. obs-local-part CFWS stripping only applies
+        // between word segments, not before the first word.
+        let e = parse(
+            "(leading) user . name@example.com",
+            Strictness::Lax,
+            false,
+            false,
+        )
+        .expect_err("leading CFWS in bare addr-spec must be rejected");
+        assert_eq!(e.kind(), &ErrorKind::InvalidLocalPartChar { ch: '(' });
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -363,7 +363,7 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
             break;
         }
         if had_cfws_before_dot && clean.is_none() {
-            let mut s = String::with_capacity(parser.input.len().saturating_sub(outer_start));
+            let mut s = String::with_capacity(last_clean_end - outer_start);
             s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
@@ -371,7 +371,7 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
         // If CFWS after dot and we haven't started clean yet, seed with
         // content before the dot — the dot is appended below via push('.').
         if clean.is_none() && parser.pos > last_clean_end + 1 {
-            let mut s = String::with_capacity(parser.input.len().saturating_sub(outer_start));
+            let mut s = String::with_capacity(last_clean_end - outer_start);
             s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
@@ -525,13 +525,13 @@ fn parse_dot_atom_domain(
             break;
         }
         if had_cfws_before_dot && clean.is_none() {
-            let mut s = String::with_capacity(parser.input.len().saturating_sub(outer_start));
+            let mut s = String::with_capacity(last_clean_end - outer_start);
             s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }
         skip_cfws(parser, 0);
         if clean.is_none() && parser.pos > last_clean_end + 1 {
-            let mut s = String::with_capacity(parser.input.len().saturating_sub(outer_start));
+            let mut s = String::with_capacity(last_clean_end - outer_start);
             s.push_str(&parser.input[outer_start..last_clean_end]);
             clean = Some(s);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,6 +26,26 @@ pub(crate) struct Parsed<'a> {
     /// Comments found during parsing.
     #[allow(dead_code)]
     pub comments: Vec<Span>,
+    /// Clean local-part with CFWS stripped (only set for obs-local-part with CFWS).
+    pub local_part_clean: Option<String>,
+    /// Clean domain with CFWS stripped (only set for obs-domain with CFWS).
+    pub domain_clean: Option<String>,
+}
+
+impl<'a> Parsed<'a> {
+    /// Effective local-part content: CFWS-stripped version if available, otherwise raw span.
+    pub fn local_part_str(&self) -> &str {
+        self.local_part_clean
+            .as_deref()
+            .unwrap_or_else(|| self.local_part.as_str(self.input))
+    }
+
+    /// Effective domain content: CFWS-stripped version if available, otherwise raw span.
+    pub fn domain_str(&self) -> &str {
+        self.domain_clean
+            .as_deref()
+            .unwrap_or_else(|| self.domain.as_str(self.input))
+    }
 }
 
 /// A byte-offset range into the input string.
@@ -149,7 +169,7 @@ pub(crate) fn parse(
     }
 
     // Parse addr-spec: local-part "@" domain
-    let local_part = parse_local_part(&mut parser, strictness)?;
+    let (local_part, local_part_clean) = parse_local_part(&mut parser, strictness)?;
     // RFC 5322 allows CFWS around "@" in Standard/Lax modes.
     if !matches!(strictness, Strictness::Strict) {
         skip_cfws(&mut parser, 0);
@@ -160,7 +180,7 @@ pub(crate) fn parse(
     if !matches!(strictness, Strictness::Strict) {
         skip_cfws(&mut parser, 0);
     }
-    let domain = parse_domain(&mut parser, strictness, allow_domain_literal)?;
+    let (domain, domain_clean) = parse_domain(&mut parser, strictness, allow_domain_literal)?;
 
     if is_angle {
         if !matches!(strictness, Strictness::Strict) {
@@ -189,6 +209,8 @@ pub(crate) fn parse(
         local_part,
         domain,
         comments: parser.comments,
+        local_part_clean,
+        domain_clean,
     })
 }
 
@@ -247,7 +269,13 @@ fn try_parse_display_name(parser: &mut Parser<'_>) -> Option<Span> {
 }
 
 /// Parse local-part: dot-atom / quoted-string / obs-local-part.
-fn parse_local_part(parser: &mut Parser<'_>, strictness: Strictness) -> Result<Span, Error> {
+///
+/// Returns `(span, clean)` where `clean` is `Some(String)` when obs-local-part
+/// contained CFWS that was stripped from the semantic value.
+fn parse_local_part(
+    parser: &mut Parser<'_>,
+    strictness: Strictness,
+) -> Result<(Span, Option<String>), Error> {
     let start = parser.pos;
     let allow_obs = matches!(strictness, Strictness::Lax);
 
@@ -259,73 +287,102 @@ fn parse_local_part(parser: &mut Parser<'_>, strictness: Strictness) -> Result<S
         if !allow_obs {
             // Standard mode: quoted-string is the entire local-part.
             parse_quoted_string(parser)?;
-            return Ok(Span::new(start, parser.pos));
+            return Ok((Span::new(start, parser.pos), None));
         }
         // Lax mode: fall through — obs-local-part allows quoted-string as first word,
         // followed by optional "." word segments.
     }
 
     // dot-atom (or obs-local-part if Lax)
-    parse_dot_atom_local(parser, allow_obs)?;
+    let clean = parse_dot_atom_local(parser, allow_obs)?;
 
     let end = parser.pos;
     if end == start {
         return Err(parser.error(ErrorKind::EmptyLocalPart));
     }
 
-    Ok(Span::new(start, end))
+    Ok((Span::new(start, end), clean))
 }
 
 /// Parse dot-atom for local-part: `atext+ ("." atext+)*`.
 /// If `allow_obs` is true, allows CFWS between atoms (obs-local-part).
-// TODO: CFWS between atoms is included in the Span — strip it for clean semantics (#13)
-fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<(), Error> {
-    // First word: atext-run, or (in obs mode) optional CFWS + atext-run or quoted-string.
-    if allow_obs {
-        skip_cfws(parser, 0);
-        if !eat_atext_run(parser) && !try_quoted_string(parser) {
-            return Err(parser.error(ErrorKind::EmptyLocalPart));
+///
+/// Returns `Some(clean)` when obs-mode CFWS was present and stripped,
+/// `None` when the span is already clean (zero-copy path).
+fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Option<String>, Error> {
+    if !allow_obs {
+        // Standard mode: no CFWS between atoms, span is always clean.
+        if !eat_atext_run(parser) {
+            return Err(match parser.peek() {
+                Some(ch) if ch != '@' => parser.error(ErrorKind::InvalidLocalPartChar { ch }),
+                _ => parser.error(ErrorKind::EmptyLocalPart),
+            });
         }
-    } else if !eat_atext_run(parser) {
-        return Err(match parser.peek() {
-            // Non-atext char present → report the offending character.
-            Some(ch) if ch != '@' => parser.error(ErrorKind::InvalidLocalPartChar { ch }),
-            // Truly empty (at `@` or EOF).
-            _ => parser.error(ErrorKind::EmptyLocalPart),
-        });
+        loop {
+            let save = parser.save();
+            if !parser.eat('.') {
+                parser.restore(save);
+                break;
+            }
+            if !eat_atext_run(parser) {
+                return Err(parser.error(ErrorKind::EmptyLocalPart));
+            }
+        }
+        return Ok(None);
     }
+
+    // Obs mode: collect atom spans for clean reconstruction.
+    let outer_start = parser.pos;
+    let mut atoms: Vec<&str> = Vec::new();
+    let mut had_cfws = false;
+
+    // First word: optional CFWS + atext-run or quoted-string.
+    let before = parser.pos;
+    skip_cfws(parser, 0);
+    if parser.pos > before {
+        had_cfws = true;
+    }
+    let atom_start = parser.pos;
+    if !eat_atext_run(parser) && !try_quoted_string(parser) {
+        return Err(parser.error(ErrorKind::EmptyLocalPart));
+    }
+    atoms.push(&parser.input[atom_start..parser.pos]);
 
     // Subsequent ".atom" segments
     loop {
         let save = parser.save();
-        if allow_obs {
-            skip_cfws(parser, 0);
+        let before = parser.pos;
+        skip_cfws(parser, 0);
+        if parser.pos > before {
+            had_cfws = true;
         }
         if !parser.eat('.') {
             parser.restore(save);
             break;
         }
-        if allow_obs {
-            skip_cfws(parser, 0);
+        let before = parser.pos;
+        skip_cfws(parser, 0);
+        if parser.pos > before {
+            had_cfws = true;
         }
-        if allow_obs {
-            // In obs mode, allow either another atext run or a quoted-string segment.
-            if !eat_atext_run(parser) && !try_quoted_string(parser) {
-                // Trailing dot or invalid local-part after consuming '.' — report an error
-                // instead of backtracking and truncating the local-part.
-                return Err(parser.error(ErrorKind::EmptyLocalPart));
-            }
-        } else {
-            // In standard mode, quoted-string after '.' is not allowed (no obs-local-part).
-            if !eat_atext_run(parser) {
-                // Trailing dot: "." must be followed by another atom/quoted-string.
-                // Report an explicit local-part error instead of backtracking and truncating.
-                return Err(parser.error(ErrorKind::EmptyLocalPart));
-            }
+        let atom_start = parser.pos;
+        if !eat_atext_run(parser) && !try_quoted_string(parser) {
+            return Err(parser.error(ErrorKind::EmptyLocalPart));
         }
+        atoms.push(&parser.input[atom_start..parser.pos]);
     }
 
-    Ok(())
+    if had_cfws {
+        Ok(Some(atoms.join(".")))
+    } else {
+        // No CFWS found — verify span is clean (debug sanity check).
+        debug_assert_eq!(
+            &parser.input[outer_start..parser.pos],
+            atoms.join("."),
+            "obs-local-part without CFWS should match raw span"
+        );
+        Ok(None)
+    }
 }
 
 /// Consume one or more atext characters. Returns true if any consumed.
@@ -392,11 +449,14 @@ fn try_quoted_string(parser: &mut Parser<'_>) -> bool {
 }
 
 /// Parse domain: dot-atom / domain-literal / obs-domain.
+///
+/// Returns `(span, clean)` where `clean` is `Some(String)` when obs-domain
+/// contained CFWS that was stripped from the semantic value.
 fn parse_domain(
     parser: &mut Parser<'_>,
     strictness: Strictness,
     allow_domain_literal: bool,
-) -> Result<Span, Error> {
+) -> Result<(Span, Option<String>), Error> {
     let start = parser.pos;
 
     // Domain literal: [...]
@@ -405,45 +465,83 @@ fn parse_domain(
             return Err(parser.error(ErrorKind::InvalidDomainChar { ch: '[' }));
         }
         parse_domain_literal(parser, strictness)?;
-        return Ok(Span::new(start, parser.pos));
+        return Ok((Span::new(start, parser.pos), None));
     }
 
     // dot-atom domain
     let allow_obs = matches!(strictness, Strictness::Lax);
-    parse_dot_atom_domain(parser, allow_obs)?;
+    let clean = parse_dot_atom_domain(parser, allow_obs)?;
 
     let end = parser.pos;
     if end == start {
         return Err(parser.error(ErrorKind::EmptyDomain));
     }
 
-    Ok(Span::new(start, end))
+    Ok((Span::new(start, end), clean))
 }
 
 /// Parse dot-atom for domain: `label ("." label)*` where label avoids leading/trailing hyphen.
-// TODO: CFWS between labels is included in the Span — strip it for clean semantics (#13)
-fn parse_dot_atom_domain(parser: &mut Parser<'_>, allow_obs: bool) -> Result<(), Error> {
+///
+/// Returns `Some(clean)` when obs-mode CFWS was present and stripped,
+/// `None` when the span is already clean (zero-copy path).
+fn parse_dot_atom_domain(
+    parser: &mut Parser<'_>,
+    allow_obs: bool,
+) -> Result<Option<String>, Error> {
+    if !allow_obs {
+        // Standard mode: no CFWS between labels, span is always clean.
+        parse_domain_label(parser)?;
+        loop {
+            let save = parser.save();
+            if !parser.eat('.') {
+                parser.restore(save);
+                break;
+            }
+            parse_domain_label(parser)?;
+        }
+        return Ok(None);
+    }
+
+    // Obs mode: collect label spans for clean reconstruction.
+    let outer_start = parser.pos;
+    let mut labels: Vec<&str> = Vec::new();
+    let mut had_cfws = false;
+
+    let label_start = parser.pos;
     parse_domain_label(parser)?;
+    labels.push(&parser.input[label_start..parser.pos]);
 
     loop {
         let save = parser.save();
-        if allow_obs {
-            skip_cfws(parser, 0);
+        let before = parser.pos;
+        skip_cfws(parser, 0);
+        if parser.pos > before {
+            had_cfws = true;
         }
         if !parser.eat('.') {
             parser.restore(save);
             break;
         }
-        if allow_obs {
-            skip_cfws(parser, 0);
+        let before = parser.pos;
+        skip_cfws(parser, 0);
+        if parser.pos > before {
+            had_cfws = true;
         }
-        // Once '.' is consumed, the next label must be valid — propagate
-        // the error so trailing dots and consecutive dots give domain-specific
-        // errors instead of a generic "unexpected character".
+        let label_start = parser.pos;
         parse_domain_label(parser)?;
+        labels.push(&parser.input[label_start..parser.pos]);
     }
 
-    Ok(())
+    if had_cfws {
+        Ok(Some(labels.join(".")))
+    } else {
+        debug_assert_eq!(
+            &parser.input[outer_start..parser.pos],
+            labels.join("."),
+            "obs-domain without CFWS should match raw span"
+        );
+        Ok(None)
+    }
 }
 
 /// Parse a single domain label: starts and ends with alnum, may contain hyphens.
@@ -729,7 +827,6 @@ mod tests {
             .unwrap_or_else(|e| panic!("failed to parse '{input}': {e}"))
     }
 
-    #[allow(dead_code)]
     fn parse_ok_lax(input: &str) -> Parsed<'_> {
         parse(input, Strictness::Lax, false, false)
             .unwrap_or_else(|e| panic!("failed to parse '{input}': {e}"))
@@ -978,5 +1075,87 @@ mod tests {
         let e = parse("user@[192.168.1.1]", Strictness::Standard, false, false)
             .expect_err("expected error");
         assert_eq!(e.kind(), &ErrorKind::InvalidDomainChar { ch: '[' });
+    }
+
+    // ── Regression tests for #13: CFWS stripping in obs-local-part / obs-domain ──
+
+    #[test]
+    fn obs_local_part_cfws_comment_stripped() {
+        // obs-local-part with comment between atoms: span must not include CFWS.
+        let p = parse_ok_lax("user (comment) . name@example.com");
+        assert_eq!(
+            p.local_part_str(),
+            "user.name",
+            "CFWS comment must be stripped from obs-local-part"
+        );
+    }
+
+    #[test]
+    fn obs_local_part_whitespace_stripped() {
+        // obs-local-part with plain whitespace between atoms.
+        let p = parse_ok_lax("user . name@example.com");
+        assert_eq!(
+            p.local_part_str(),
+            "user.name",
+            "whitespace must be stripped from obs-local-part"
+        );
+    }
+
+    #[test]
+    fn obs_domain_cfws_comment_stripped() {
+        // obs-domain with comment between labels: span must not include CFWS.
+        let p = parse_ok_lax("user@example (comment) . com");
+        assert_eq!(
+            p.domain_str(),
+            "example.com",
+            "CFWS comment must be stripped from obs-domain"
+        );
+    }
+
+    #[test]
+    fn obs_domain_whitespace_stripped() {
+        // obs-domain with plain whitespace between labels.
+        let p = parse_ok_lax("user@example . com");
+        assert_eq!(
+            p.domain_str(),
+            "example.com",
+            "whitespace must be stripped from obs-domain"
+        );
+    }
+
+    #[test]
+    fn obs_local_no_cfws_zero_copy() {
+        // obs-local-part without CFWS: clean field is None (zero-copy path).
+        let p = parse_ok_lax("user.name@example.com");
+        assert!(
+            p.local_part_clean.is_none(),
+            "no CFWS → local_part_clean must be None (zero-copy)"
+        );
+        assert_eq!(p.local_part_str(), "user.name");
+    }
+
+    #[test]
+    fn obs_domain_no_cfws_zero_copy() {
+        // obs-domain without CFWS: clean field is None (zero-copy path).
+        let p = parse_ok_lax("user@example.com");
+        assert!(
+            p.domain_clean.is_none(),
+            "no CFWS → domain_clean must be None (zero-copy)"
+        );
+        assert_eq!(p.domain_str(), "example.com");
+    }
+
+    #[test]
+    fn obs_local_part_multiple_comments_stripped() {
+        // Multiple CFWS segments between atoms.
+        let p = parse_ok_lax("a (c1) . b (c2) . c@example.com");
+        assert_eq!(p.local_part_str(), "a.b.c");
+    }
+
+    #[test]
+    fn obs_local_part_leading_cfws_stripped() {
+        // Leading CFWS before first atom in obs-local-part.
+        let p = parse_ok_lax("(leading) user . name@example.com");
+        assert_eq!(p.local_part_str(), "user.name");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -331,72 +331,61 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
         return Ok(None);
     }
 
-    // Obs mode: parse atoms and track CFWS presence.
-    // Atom boundaries stored on the stack to avoid heap allocation
-    // when no CFWS is present (the common case).
-    // RFC 5321: local-part ≤ 64 octets → max 32 single-char atoms.
-    const MAX_ATOMS: usize = 32;
-    let mut bounds: [(usize, usize); MAX_ATOMS] = [(0, 0); MAX_ATOMS];
-    let mut count = 0;
-    let mut had_cfws = false;
+    // Obs mode: parse atoms, building a clean string only when CFWS is present.
+    // Zero allocation in the common no-CFWS path. When CFWS is first detected,
+    // the contiguous prefix (all prior atoms+dots, no CFWS gaps) is copied
+    // from the raw span, then subsequent atoms are appended incrementally.
+    let mut clean: Option<String> = None;
+    let outer_start = parser.pos;
 
     // First word: no leading CFWS — bare addr-spec does not permit CFWS
     // before the local-part. CFWS stripping only applies between segments.
-    let atom_start = parser.pos;
     if !eat_atext_run(parser) && !try_quoted_string(parser) {
         return Err(match parser.peek() {
             Some(ch) if ch != '@' => parser.error(ErrorKind::InvalidLocalPartChar { ch }),
             _ => parser.error(ErrorKind::EmptyLocalPart),
         });
     }
-    bounds[count] = (atom_start, parser.pos);
-    count += 1;
 
     // Subsequent ".atom" segments
     loop {
+        // `last_clean_end` marks the end of contiguous clean content before
+        // any CFWS in this iteration. Used as prefix boundary if CFWS is
+        // detected for the first time.
+        let last_clean_end = parser.pos;
         let save = parser.save();
         let comments_len = parser.comments.len();
-        let cfws_before_dot = parser.pos;
         skip_cfws(parser, 0);
-        let had_cfws_before_dot = parser.pos > cfws_before_dot;
+        let had_cfws_before_dot = parser.pos > last_clean_end;
         if !parser.eat('.') {
-            // No dot — trailing CFWS before @/>/EOF. Restore position and
-            // undo tentative comment spans added by skip_cfws.
             parser.restore(save);
             parser.comments.truncate(comments_len);
             break;
         }
-        // Dot consumed — CFWS before the dot IS between atoms.
-        if had_cfws_before_dot {
-            had_cfws = true;
+        if had_cfws_before_dot && clean.is_none() {
+            let mut s = String::with_capacity(64);
+            s.push_str(&parser.input[outer_start..last_clean_end]);
+            clean = Some(s);
         }
-        let before = parser.pos;
         skip_cfws(parser, 0);
-        if parser.pos > before {
-            had_cfws = true;
+        // If CFWS after dot and we haven't started clean yet, the prefix
+        // extends through the dot (last_clean_end + 1 byte for '.').
+        if clean.is_none() && parser.pos > last_clean_end + 1 {
+            let mut s = String::with_capacity(64);
+            s.push_str(&parser.input[outer_start..last_clean_end + 1]);
+            clean = Some(s);
         }
         let atom_start = parser.pos;
         if !eat_atext_run(parser) && !try_quoted_string(parser) {
             return Err(parser.error(ErrorKind::EmptyLocalPart));
         }
-        if count < MAX_ATOMS {
-            bounds[count] = (atom_start, parser.pos);
-            count += 1;
+        if let Some(ref mut s) = clean {
+            s.push('.');
+            s.push_str(&parser.input[atom_start..parser.pos]);
         }
     }
 
-    if had_cfws {
-        let mut clean = String::with_capacity(bounds[count - 1].1 - bounds[0].0);
-        for (i, &(start, end)) in bounds[..count].iter().enumerate() {
-            if i > 0 {
-                clean.push('.');
-            }
-            clean.push_str(&parser.input[start..end]);
-        }
-        Ok(Some(clean))
-    } else {
-        Ok(None)
-    }
+    Ok(clean)
 }
 
 /// Consume one or more atext characters. Returns true if any consumed.
@@ -516,61 +505,45 @@ fn parse_dot_atom_domain(
         return Ok(None);
     }
 
-    // Obs mode: parse labels and track CFWS presence.
-    // Label boundaries stored on the stack to avoid heap allocation
-    // when no CFWS is present (the common case).
-    const MAX_LABELS: usize = 16; // DNS: max 127 labels, but 16 covers all real domains
-    let mut bounds: [(usize, usize); MAX_LABELS] = [(0, 0); MAX_LABELS];
-    let mut count = 0;
-    let mut had_cfws = false;
+    // Obs mode: parse labels, building a clean string only when CFWS is present.
+    // Zero allocation in the common no-CFWS path. Same incremental strategy
+    // as parse_dot_atom_local — see that function for detailed comments.
+    let mut clean: Option<String> = None;
+    let outer_start = parser.pos;
 
-    let label_start = parser.pos;
     parse_domain_label(parser)?;
-    bounds[count] = (label_start, parser.pos);
-    count += 1;
 
     loop {
+        let last_clean_end = parser.pos;
         let save = parser.save();
         let comments_len = parser.comments.len();
-        let cfws_before_dot = parser.pos;
         skip_cfws(parser, 0);
-        let had_cfws_before_dot = parser.pos > cfws_before_dot;
+        let had_cfws_before_dot = parser.pos > last_clean_end;
         if !parser.eat('.') {
-            // No dot — trailing CFWS before >/EOF. Restore position and
-            // undo tentative comment spans added by skip_cfws.
             parser.restore(save);
             parser.comments.truncate(comments_len);
             break;
         }
-        // Dot consumed — CFWS before the dot IS between labels.
-        if had_cfws_before_dot {
-            had_cfws = true;
+        if had_cfws_before_dot && clean.is_none() {
+            let mut s = String::with_capacity(64);
+            s.push_str(&parser.input[outer_start..last_clean_end]);
+            clean = Some(s);
         }
-        let before = parser.pos;
         skip_cfws(parser, 0);
-        if parser.pos > before {
-            had_cfws = true;
+        if clean.is_none() && parser.pos > last_clean_end + 1 {
+            let mut s = String::with_capacity(64);
+            s.push_str(&parser.input[outer_start..last_clean_end + 1]);
+            clean = Some(s);
         }
         let label_start = parser.pos;
         parse_domain_label(parser)?;
-        if count < MAX_LABELS {
-            bounds[count] = (label_start, parser.pos);
-            count += 1;
+        if let Some(ref mut s) = clean {
+            s.push('.');
+            s.push_str(&parser.input[label_start..parser.pos]);
         }
     }
 
-    if had_cfws {
-        let mut clean = String::with_capacity(bounds[count - 1].1 - bounds[0].0);
-        for (i, &(start, end)) in bounds[..count].iter().enumerate() {
-            if i > 0 {
-                clean.push('.');
-            }
-            clean.push_str(&parser.input[start..end]);
-        }
-        Ok(Some(clean))
-    } else {
-        Ok(None)
-    }
+    Ok(clean)
 }
 
 /// Parse a single domain label: starts and ends with alnum, may contain hyphens.

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -25,8 +25,8 @@ pub(crate) fn validate(
 
     // Length limits apply to the RAW addr-spec (RFC 5321 §4.5.3.1),
     // not the normalized form (which may be shorter after tag/dot stripping).
-    let raw_local = parsed.local_part.as_str(parsed.input);
-    let raw_domain = parsed.domain.as_str(parsed.input);
+    let raw_local = parsed.local_part_str();
+    let raw_domain = parsed.domain_str();
 
     // Length: local part (max 64 octets).
     if raw_local.len() > MAX_LOCAL_PART_LEN {

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -23,23 +23,21 @@ pub(crate) fn validate(
 ) -> Result<(), Error> {
     let domain = &normalized.domain;
 
-    // Length limits apply to the RAW addr-spec (RFC 5321 §4.5.3.1),
-    // not the normalized form (which may be shorter after tag/dot stripping).
-    let raw_local = parsed.local_part_str();
-    let raw_domain = parsed.domain_str();
+    // Length limits apply to the semantic addr-spec content (RFC 5321 §4.5.3.1),
+    // with CFWS stripped (obs-forms), but before normalization (tag/dot stripping).
+    let local = parsed.local_part_str();
+    let domain_str = parsed.domain_str();
 
     // Length: local part (max 64 octets).
-    if raw_local.len() > MAX_LOCAL_PART_LEN {
+    if local.len() > MAX_LOCAL_PART_LEN {
         return Err(Error::new(
-            ErrorKind::LocalPartTooLong {
-                len: raw_local.len(),
-            },
+            ErrorKind::LocalPartTooLong { len: local.len() },
             parsed.local_part.start,
         ));
     }
 
     // Length: total address (max 254 octets).
-    let total = raw_local.len() + 1 + raw_domain.len();
+    let total = local.len() + 1 + domain_str.len();
     if total > MAX_ADDRESS_LEN {
         return Err(Error::new(
             ErrorKind::AddressTooLong { len: total },
@@ -48,7 +46,7 @@ pub(crate) fn validate(
     }
 
     // Domain literals like [192.168.1.1] get special handling below.
-    let is_domain_literal = raw_domain.starts_with('[');
+    let is_domain_literal = domain_str.starts_with('[');
 
     // Domain must have at least one dot (unless configured otherwise).
     if config.require_tld_dot && !domain.contains('.') && !is_domain_literal {


### PR DESCRIPTION
## Summary

- In Lax mode, `skip_cfws()` between atoms advanced `parser.pos`, making spans include CFWS/comment characters in semantic local-part and domain values
- Now builds a clean String incrementally when CFWS is detected — zero allocation in the common no-CFWS path (`Option<String>` stays `None`)
- Adds `local_part_clean` / `domain_clean` optional fields to `Parsed` with `local_part_str()` / `domain_str()` accessors
- Updates `normalize.rs` and `validate.rs` to use CFWS-stripped content

## Technical Details

**Before:** `user (comment) . name@example.com` → local_part span = `user (comment) . name`
**After:** `user (comment) . name@example.com` → `local_part_str()` returns `user.name`

Key design decisions:
- **Incremental String builder**: when CFWS is first detected, the contiguous clean prefix is copied from the raw span, then subsequent atoms are appended directly. No bounds arrays, no capacity limits
- **Prefix-length capacity**: `String::with_capacity(last_clean_end - outer_start)` — sizes to the known prefix, not the remaining input
- **Deferred allocation**: `had_cfws` flag only set after a dot is successfully consumed; trailing CFWS before `@`/`>`/EOF is backtracked without allocation
- **Comment span backtracking**: `parser.comments` truncated alongside `parser.pos` on backtrack
- **No leading CFWS**: bare addr-spec rejects leading RFC 5322 comments before the first word

## Test Plan

- [x] 14 regression tests: CFWS between atoms (comments + whitespace), CFWS-after-dot, multiple segments, obs-domain CFWS, zero-copy verification, trailing CFWS preserves zero-copy with comment count assertion, leading comment rejected, end-to-end normalization (case folding + IDNA)
- [x] All 80 tests pass (66 existing + 14 new)
- [x] 5 doc-tests pass
- [x] Clippy clean (zero warnings, all features)

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Comments and whitespace within email addresses are now correctly stripped during validation and normalization
  * Length validation constraints are now calculated on semantic content, not raw input with comments
  * Domain literal detection improved for addresses containing whitespace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->