### PR TITLE
fix(parser): harden RFC 5321/5322 conformance (CFWS, CR/LF, IP literals)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +604,7 @@ dependencies = [
  "idna",
  "psl",
  "rayon",
+ "roxmltree",
  "serde",
  "serde_json",
  "unicode-normalization",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,12 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "roxmltree"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rustversion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rayon = { version = "1", optional = true }
 [dev-dependencies]
 serde_json = "1"
 criterion = { version = "0.8", features = ["html_reports"] }
-roxmltree = "0.21"
+roxmltree = "0.21.1"
 
 [[bench]]
 name = "email"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rayon = { version = "1", optional = true }
 [dev-dependencies]
 serde_json = "1"
 criterion = { version = "0.8", features = ["html_reports"] }
-roxmltree = "0.20"
+roxmltree = "0.21"
 
 [[bench]]
 name = "email"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rayon = { version = "1", optional = true }
 [dev-dependencies]
 serde_json = "1"
 criterion = { version = "0.8", features = ["html_reports"] }
+roxmltree = "0.20"
 
 [[bench]]
 name = "email"

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ assert_eq!(
 );
 ```
 
+## Conformance
+
+Validated against the [isEmail](https://github.com/dominicsayers/isemail) test
+suite (v3.05, 164 edge cases), the same corpus used by `email-address-parser`.
+All 164 cases pass: valid addresses (RFC 5321/5322 quoted strings, IPv4/IPv6
+address literals, comments, folding whitespace, obsolete forms) are accepted at
+the appropriate strictness level, while malformed inputs (bad IP literals,
+over-length parts, bare control characters) are rejected. See
+[`tests/conformance.rs`](tests/conformance.rs).
+
 ## Support the Project
 
 <div align="center">

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,9 @@ pub enum ErrorKind {
     UnterminatedComment,
     /// Unterminated domain literal `[...]`.
     UnterminatedDomainLiteral,
+    /// Domain literal `[...]` is not a valid IPv4 or `IPv6:` address literal
+    /// (RFC 5321 §4.1.3). General domain literals are not accepted.
+    InvalidAddressLiteral,
     /// IDNA encoding failed for domain.
     IdnaError(String),
     /// Domain not in Public Suffix List (when PSL validation enabled).
@@ -97,6 +100,12 @@ impl fmt::Display for Error {
             ErrorKind::InvalidQuotedPair => write!(f, "invalid quoted-pair escape"),
             ErrorKind::UnterminatedComment => write!(f, "unterminated comment"),
             ErrorKind::UnterminatedDomainLiteral => write!(f, "unterminated domain literal"),
+            ErrorKind::InvalidAddressLiteral => {
+                write!(
+                    f,
+                    "domain literal is not a valid IPv4 or IPv6 address literal"
+                )
+            }
             ErrorKind::IdnaError(msg) => write!(f, "IDNA encoding failed: {msg}"),
             ErrorKind::UnknownTld(tld) => write!(f, "unknown TLD: .{tld}"),
             ErrorKind::Unexpected { ch } => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -120,3 +120,44 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_and_accessors_cover_all_kinds() {
+        // Every ErrorKind must render a non-empty message, and the accessors
+        // must round-trip the kind and position.
+        let kinds = [
+            ErrorKind::Empty,
+            ErrorKind::MissingAtSign,
+            ErrorKind::EmptyLocalPart,
+            ErrorKind::EmptyDomain,
+            ErrorKind::LocalPartTooLong { len: 65 },
+            ErrorKind::AddressTooLong { len: 300 },
+            ErrorKind::DomainLabelTooLong {
+                label: "x".to_string(),
+                len: 64,
+            },
+            ErrorKind::InvalidLocalPartChar { ch: '(' },
+            ErrorKind::InvalidDomainChar { ch: '[' },
+            ErrorKind::DomainLabelHyphen,
+            ErrorKind::DomainNoDot,
+            ErrorKind::UnterminatedQuotedString,
+            ErrorKind::InvalidQuotedPair,
+            ErrorKind::UnterminatedComment,
+            ErrorKind::UnterminatedDomainLiteral,
+            ErrorKind::InvalidAddressLiteral,
+            ErrorKind::IdnaError("boom".to_string()),
+            ErrorKind::UnknownTld("zzz".to_string()),
+            ErrorKind::Unexpected { ch: '!' },
+        ];
+        for (pos, kind) in kinds.into_iter().enumerate() {
+            let err = Error::new(kind.clone(), pos);
+            assert!(!err.to_string().is_empty(), "empty Display for {kind:?}");
+            assert_eq!(err.kind(), &kind);
+            assert_eq!(err.position(), pos);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use normalize::confusable_skeleton;
 /// Immutable after construction. All accessors return borrowed data.
 #[derive(Debug, Clone)]
 pub struct EmailAddress {
-    /// Original input (trimmed).
+    /// Original input, exactly as supplied to the parser.
     original: String,
     /// Canonical local part (after normalization).
     local_part: String,
@@ -167,7 +167,7 @@ impl EmailAddress {
         }
     }
 
-    /// The original input (trimmed).
+    /// The original input, exactly as supplied to the parser (not trimmed).
     pub fn original(&self) -> &str {
         &self.original
     }
@@ -499,6 +499,39 @@ mod tests {
         assert_eq!(email.display_name(), Some("John Doe"));
         assert_eq!(email.local_part(), "user");
         assert_eq!(email.domain(), "example.com");
+    }
+
+    #[test]
+    fn leading_comment_full_pipeline() {
+        // #40: a leading RFC 5322 comment before the local-part must parse
+        // end-to-end, with the comment stripped from the canonical address.
+        let config = Config::builder()
+            .strictness(Strictness::Lax)
+            .allow_display_name()
+            .allow_domain_literal()
+            .allow_single_label_domain()
+            .lowercase_all()
+            .build();
+
+        for input in [
+            "(comment)jane.smith@example.com",
+            "jane(comment).smith@example.com",
+            "jane.smith(comment)@example.com",
+            "jane.smith@example.com",
+        ] {
+            let email = EmailAddress::parse_with(input, &config)
+                .unwrap_or_else(|e| panic!("'{input}' must parse: {e}"));
+            assert_eq!(email.canonical(), "jane.smith@example.com");
+        }
+    }
+
+    #[test]
+    fn rejects_newline_in_address() {
+        // Header-injection hardening: a trailing newline must not be silently
+        // accepted (it previously survived an over-eager input.trim()).
+        let config = Config::default();
+        assert!("user@example.com\n".parse::<EmailAddress>().is_err());
+        assert!(EmailAddress::parse_with("user@example.com\r\n", &config).is_err());
     }
 
     // ── Serde ──

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -149,6 +149,14 @@ pub(crate) fn parse(
     let mut parser = Parser::new(input);
     let allow_obs = matches!(strictness, Strictness::Lax);
 
+    // Strip leading CFWS before choosing the display-name / angle-addr path
+    // (RFC 5322: a mailbox may be preceded by CFWS). Without this, a leading
+    // space would divert a quoted display name to the unquoted scanner. Strict
+    // (RFC 5321) forbids CFWS, so leading whitespace is left to be rejected.
+    if !matches!(strictness, Strictness::Strict) {
+        skip_cfws(&mut parser, 0);
+    }
+
     // Try name-addr format: display-name? "<" addr-spec ">"
     let display_name = if allow_display_name {
         try_parse_display_name(&mut parser, allow_obs)
@@ -625,8 +633,13 @@ fn parse_domain_literal(parser: &mut Parser<'_>) -> Result<(), Error> {
 /// (RFC 5321 §4.1.3). Uses `core::net` parsers (no-std friendly).
 fn is_address_literal(content: &str) -> bool {
     use core::net::{Ipv4Addr, Ipv6Addr};
-    if let Some(v6) = content.strip_prefix("IPv6:") {
-        return v6.parse::<Ipv6Addr>().is_ok();
+    // The "IPv6:" tag is an ABNF string literal, hence case-insensitive
+    // (RFC 5234 §2.3): `[ipv6:::1]` and `[IPV6:...]` are equally valid.
+    if content
+        .get(..5)
+        .is_some_and(|tag| tag.eq_ignore_ascii_case("IPv6:"))
+    {
+        return content[5..].parse::<Ipv6Addr>().is_ok();
     }
     content.parse::<Ipv4Addr>().is_ok()
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -338,8 +338,9 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
     let mut clean: Option<String> = None;
     let outer_start = parser.pos;
 
-    // First word: no leading CFWS — bare addr-spec does not permit CFWS
-    // before the local-part. CFWS stripping only applies between segments.
+    // First word: any leading CFWS was already consumed by the caller (`parse`
+    // skips it before the local-part). CFWS stripping here applies only between
+    // segments, so the first word starts immediately.
     if !eat_atext_run(parser) && !try_quoted_string(parser, allow_obs) {
         return Err(match parser.peek() {
             Some(ch) if ch != '@' => parser.error(ErrorKind::InvalidLocalPartChar { ch }),
@@ -836,7 +837,7 @@ fn is_quoted_pair_char(ch: char, allow_obs: bool) -> bool {
 }
 
 /// obs-NO-WS-CTL (RFC 5322 §4.1): control chars usable in obsolete qtext and
-/// quoted-pairs — %d1-8, %d11, %d12, %d14-31, %d127 (excludes TAB, LF, CR).
+/// quoted-pairs — %d1-8, %d11, %d12, %d14-31, %d127 (excludes NUL, TAB, LF, CR).
 fn is_obs_no_ws_ctl(ch: char) -> bool {
     matches!(ch as u32, 0x01..=0x08 | 0x0b | 0x0c | 0x0e..=0x1f | 0x7f)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -143,16 +143,20 @@ pub(crate) fn parse(
     allow_display_name: bool,
     allow_domain_literal: bool,
 ) -> Result<Parsed<'_>, Error> {
-    let trimmed = input.trim();
-    if trimmed.is_empty() {
+    if input.is_empty() {
         return Err(Error::new(ErrorKind::Empty, 0));
     }
 
-    let mut parser = Parser::new(trimmed);
+    // No leading/trailing trim: bare CR/LF are not strippable whitespace —
+    // accepting `user@host\n` would be a header-injection hazard. Legitimate
+    // leading/trailing CFWS (spaces, folding whitespace, comments) is consumed
+    // by skip_cfws in Standard/Lax; a bare CR/LF is left to be rejected.
+    let mut parser = Parser::new(input);
+    let allow_obs = matches!(strictness, Strictness::Lax);
 
     // Try name-addr format: display-name? "<" addr-spec ">"
     let display_name = if allow_display_name {
-        try_parse_display_name(&mut parser)
+        try_parse_display_name(&mut parser, allow_obs)
     } else {
         None
     };
@@ -168,7 +172,15 @@ pub(crate) fn parse(
         }
     }
 
-    // Parse addr-spec: local-part "@" domain
+    // Parse addr-spec: local-part "@" domain.
+    // RFC 5322 §3.2.3: local-part dot-atom permits leading [CFWS]
+    // (`dot-atom = [CFWS] dot-atom-text [CFWS]`), so a comment or folding
+    // whitespace before the local-part is valid. Strip it in Standard/Lax;
+    // RFC 5321 Strict forbids CFWS, so a leading '(' or space is left for
+    // parse_local_part to reject.
+    if !matches!(strictness, Strictness::Strict) {
+        skip_cfws(&mut parser, 0);
+    }
     let (local_part, local_part_clean) = parse_local_part(&mut parser, strictness)?;
     // RFC 5322 allows CFWS around "@" in Standard/Lax modes.
     if !matches!(strictness, Strictness::Strict) {
@@ -204,7 +216,7 @@ pub(crate) fn parse(
     }
 
     Ok(Parsed {
-        input: trimmed,
+        input,
         display_name,
         local_part,
         domain,
@@ -215,13 +227,13 @@ pub(crate) fn parse(
 }
 
 /// Try to parse a display name before `<`. Returns None and resets position on failure.
-fn try_parse_display_name(parser: &mut Parser<'_>) -> Option<Span> {
+fn try_parse_display_name(parser: &mut Parser<'_>, allow_obs: bool) -> Option<Span> {
     let save = parser.save();
 
     // Quoted display name: "Name" <addr>
     if parser.peek() == Some('"') {
         let start = parser.pos;
-        if parse_quoted_string(parser).is_err() {
+        if parse_quoted_string(parser, allow_obs).is_err() {
             parser.restore(save);
             return None;
         }
@@ -286,7 +298,7 @@ fn parse_local_part(
         }
         if !allow_obs {
             // Standard mode: quoted-string is the entire local-part.
-            parse_quoted_string(parser)?;
+            parse_quoted_string(parser, false)?;
             return Ok((Span::new(start, parser.pos), None));
         }
         // Lax mode: fall through — obs-local-part allows quoted-string as first word,
@@ -340,7 +352,7 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
 
     // First word: no leading CFWS — bare addr-spec does not permit CFWS
     // before the local-part. CFWS stripping only applies between segments.
-    if !eat_atext_run(parser) && !try_quoted_string(parser) {
+    if !eat_atext_run(parser) && !try_quoted_string(parser, allow_obs) {
         return Err(match parser.peek() {
             Some(ch) if ch != '@' => parser.error(ErrorKind::InvalidLocalPartChar { ch }),
             _ => parser.error(ErrorKind::EmptyLocalPart),
@@ -376,7 +388,7 @@ fn parse_dot_atom_local(parser: &mut Parser<'_>, allow_obs: bool) -> Result<Opti
             clean = Some(s);
         }
         let atom_start = parser.pos;
-        if !eat_atext_run(parser) && !try_quoted_string(parser) {
+        if !eat_atext_run(parser) && !try_quoted_string(parser, allow_obs) {
             return Err(parser.error(ErrorKind::EmptyLocalPart));
         }
         if let Some(ref mut s) = clean {
@@ -401,8 +413,11 @@ fn eat_atext_run(parser: &mut Parser<'_>) -> bool {
     parser.pos > start
 }
 
-/// Parse quoted-string: `"` (qtext | quoted-pair)* `"`.
-fn parse_quoted_string(parser: &mut Parser<'_>) -> Result<(), Error> {
+/// Parse quoted-string: `"` (qtext | quoted-pair | FWS)* `"`.
+///
+/// With `allow_obs`, accepts obs-qtext and obs-qp (control characters) per
+/// RFC 5322 §4.1 — used in Lax mode.
+fn parse_quoted_string(parser: &mut Parser<'_>, allow_obs: bool) -> Result<(), Error> {
     if !parser.eat('"') {
         return Err(parser.error(ErrorKind::UnterminatedQuotedString));
     }
@@ -416,11 +431,11 @@ fn parse_quoted_string(parser: &mut Parser<'_>) -> Result<(), Error> {
             Some('\\') => {
                 parser.advance();
                 match parser.advance() {
-                    Some(ch) if is_quoted_pair_char(ch) => {}
+                    Some(ch) if is_quoted_pair_char(ch, allow_obs) => {}
                     _ => return Err(parser.error(ErrorKind::InvalidQuotedPair)),
                 }
             }
-            Some(ch) if is_qtext(ch) => {
+            Some(ch) if is_qtext(ch, allow_obs) => {
                 parser.advance();
             }
             // RFC 5322 FWS: plain WSP or CRLF + WSP (folded whitespace).
@@ -438,12 +453,12 @@ fn parse_quoted_string(parser: &mut Parser<'_>) -> Result<(), Error> {
 }
 
 /// Try to parse a quoted-string without error on failure.
-fn try_quoted_string(parser: &mut Parser<'_>) -> bool {
+fn try_quoted_string(parser: &mut Parser<'_>, allow_obs: bool) -> bool {
     if parser.peek() != Some('"') {
         return false;
     }
     let save = parser.save();
-    if parse_quoted_string(parser).is_ok() {
+    if parse_quoted_string(parser, allow_obs).is_ok() {
         true
     } else {
         parser.restore(save);
@@ -467,7 +482,7 @@ fn parse_domain(
         if !allow_domain_literal {
             return Err(parser.error(ErrorKind::InvalidDomainChar { ch: '[' }));
         }
-        parse_domain_literal(parser, strictness)?;
+        parse_domain_literal(parser)?;
         return Ok((Span::new(start, parser.pos), None));
     }
 
@@ -578,41 +593,57 @@ fn parse_domain_label(parser: &mut Parser<'_>) -> Result<(), Error> {
     Ok(())
 }
 
-/// Parse domain literal: `[` dtext* `]`.
-fn parse_domain_literal(parser: &mut Parser<'_>, strictness: Strictness) -> Result<(), Error> {
+/// Parse domain literal: `[` ... `]`, accepting only valid RFC 5321 §4.1.3
+/// address literals — an IPv4 dotted-quad or an `IPv6:`-tagged IPv6 address.
+///
+/// General RFC 5322 domain literals (arbitrary `dtext`, e.g.
+/// `[RFC-5322-domain-literal]`) and malformed IP literals (`[255.255.255]`,
+/// `[IPv6:1::2:]`) are syntactically consumed but rejected with
+/// [`ErrorKind::InvalidAddressLiteral`]: a non-IP literal is not a usable mail
+/// destination. This matches the isEmail conformance baseline, which classifies
+/// such tokens as RFC 5322-only (not valid RFC 5321 addresses).
+fn parse_domain_literal(parser: &mut Parser<'_>) -> Result<(), Error> {
+    let open = parser.pos;
     if !parser.eat('[') {
         return Err(parser.error(ErrorKind::UnterminatedDomainLiteral));
     }
-
+    let content_start = parser.pos;
     loop {
         match parser.peek() {
             Some(']') => {
-                parser.advance();
-                return Ok(());
-            }
-            // obs-dtext allows quoted-pair in Lax mode.
-            Some('\\') if matches!(strictness, Strictness::Lax) => {
-                parser.advance();
-                match parser.advance() {
-                    Some(ch) if is_quoted_pair_char(ch) => {}
-                    _ => return Err(parser.error(ErrorKind::InvalidQuotedPair)),
+                let content = &parser.input[content_start..parser.pos];
+                parser.advance(); // consume ']'
+                if is_address_literal(content) {
+                    return Ok(());
                 }
+                return Err(Error::new(ErrorKind::InvalidAddressLiteral, open));
             }
-            Some(ch) if is_dtext(ch) => {
+            // A backslash escapes the next char (obs-dtext); consume both so an
+            // escaped ']' does not close the literal early. The resulting
+            // content fails IP validation above, so the literal is rejected.
+            Some('\\') => {
                 parser.advance();
-            }
-            // RFC 5322 FWS: plain WSP or CRLF + WSP (folded whitespace).
-            Some(ch) if is_wsp(ch) || ch == '\r' => {
-                if !try_eat_fws(parser) {
-                    return Err(parser.error(ErrorKind::InvalidDomainChar { ch: '\r' }));
+                if parser.advance().is_none() {
+                    return Err(parser.error(ErrorKind::UnterminatedDomainLiteral));
                 }
             }
             None => return Err(parser.error(ErrorKind::UnterminatedDomainLiteral)),
-            Some(ch) => {
-                return Err(parser.error(ErrorKind::InvalidDomainChar { ch }));
+            Some(_) => {
+                parser.advance();
             }
         }
     }
+}
+
+/// Returns true if the domain-literal content (the text between `[` and `]`)
+/// is a valid IPv4 address literal or an `IPv6:`-tagged IPv6 address literal
+/// (RFC 5321 §4.1.3). Uses `core::net` parsers (no-std friendly).
+fn is_address_literal(content: &str) -> bool {
+    use core::net::{Ipv4Addr, Ipv6Addr};
+    if let Some(v6) = content.strip_prefix("IPv6:") {
+        return v6.parse::<Ipv6Addr>().is_ok();
+    }
+    content.parse::<Ipv4Addr>().is_ok()
 }
 
 /// Try to consume one FWS token: either plain WSP, or CRLF followed by at least one WSP.
@@ -741,19 +772,28 @@ fn parse_comment(parser: &mut Parser<'_>, depth: usize) -> Result<(), Error> {
                 // Nested comment
                 parse_comment(parser, depth + 1)?;
             }
+            // A comment is free-form CFWS: a backslash escapes any following
+            // character (including obs-qp control chars). Only a trailing
+            // backslash at end-of-input is an error.
             Some('\\') => {
                 parser.advance();
-                match parser.advance() {
-                    Some(ch) if is_quoted_pair_char(ch) => {}
-                    _ => return Err(parser.error(ErrorKind::InvalidQuotedPair)),
+                if parser.advance().is_none() {
+                    return Err(parser.error(ErrorKind::UnterminatedComment));
                 }
             }
             Some(ch) if is_ctext(ch) || is_wsp(ch) => {
                 parser.advance();
             }
+            // Inside a comment, CR/LF is only valid as folding whitespace
+            // (CRLF + WSP). A bare CR or LF is invalid (e.g. `(\r)`).
+            Some('\r') | Some('\n') => {
+                if !try_eat_fws(parser) {
+                    return Err(parser.error(ErrorKind::UnterminatedComment));
+                }
+            }
             None => return Err(parser.error(ErrorKind::UnterminatedComment)),
             Some(_) => {
-                parser.advance(); // be lenient in comments
+                parser.advance(); // be lenient in comments (obs-ctext controls)
             }
         }
     }
@@ -788,9 +828,13 @@ fn is_atext(ch: char) -> bool {
         )
 }
 
-/// qtext: printable ASCII except `"` and `\`, plus UTF-8 non-ASCII.
-fn is_qtext(ch: char) -> bool {
-    ch != '"' && ch != '\\' && (is_printable_ascii(ch) || is_utf8_non_ascii(ch))
+/// qtext (RFC 5322 §3.2.4): printable ASCII except `"` and `\`, plus UTF-8
+/// non-ASCII. With `allow_obs`, also accepts obs-qtext (obs-NO-WS-CTL controls).
+fn is_qtext(ch: char, allow_obs: bool) -> bool {
+    if ch == '"' || ch == '\\' {
+        return false;
+    }
+    is_printable_ascii(ch) || is_utf8_non_ascii(ch) || (allow_obs && is_obs_no_ws_ctl(ch))
 }
 
 /// ctext: printable ASCII except `(`, `)`, `\`, plus UTF-8 non-ASCII.
@@ -798,14 +842,21 @@ fn is_ctext(ch: char) -> bool {
     ch != '(' && ch != ')' && ch != '\\' && (is_printable_ascii(ch) || is_utf8_non_ascii(ch))
 }
 
-/// dtext: printable ASCII except `[`, `]`, `\`, plus UTF-8 non-ASCII.
-fn is_dtext(ch: char) -> bool {
-    ch != '[' && ch != ']' && ch != '\\' && (is_printable_ascii(ch) || is_utf8_non_ascii(ch))
+/// Characters valid in a quoted-pair after `\` (RFC 5322 §3.2.1: `quoted-pair =
+/// "\" (VCHAR / WSP)`). Non-ASCII is intentionally excluded — RFC 6531 allows
+/// UTF-8 directly in qtext, so escaping it is invalid. With `allow_obs`, also
+/// accepts obs-qp: NUL, CR, LF, and obs-NO-WS-CTL controls.
+fn is_quoted_pair_char(ch: char, allow_obs: bool) -> bool {
+    if is_printable_ascii(ch) || is_wsp(ch) {
+        return true;
+    }
+    allow_obs && (matches!(ch, '\0' | '\n' | '\r') || is_obs_no_ws_ctl(ch))
 }
 
-/// Characters valid in a quoted-pair after `\`.
-fn is_quoted_pair_char(ch: char) -> bool {
-    is_printable_ascii(ch) || is_wsp(ch) || is_utf8_non_ascii(ch)
+/// obs-NO-WS-CTL (RFC 5322 §4.1): control chars usable in obsolete qtext and
+/// quoted-pairs — %d1-8, %d11, %d12, %d14-31, %d127 (excludes TAB, LF, CR).
+fn is_obs_no_ws_ctl(ch: char) -> bool {
+    matches!(ch as u32, 0x01..=0x08 | 0x0b | 0x0c | 0x0e..=0x1f | 0x7f)
 }
 
 fn is_printable_ascii(ch: char) -> bool {
@@ -1155,18 +1206,20 @@ mod tests {
     }
 
     #[test]
-    fn obs_leading_comment_rejected_in_bare_addr_spec() {
-        // Leading RFC 5322 comments before local-part are rejected in bare
-        // addr-spec. Note: leading plain whitespace is handled by input.trim()
-        // before parsing, so this test covers comments specifically.
-        let e = parse(
+    fn obs_leading_comment_accepted_in_bare_addr_spec() {
+        // RFC 5322 §3.2.3: local-part dot-atom permits leading [CFWS]
+        // (`dot-atom = [CFWS] dot-atom-text [CFWS]`), so a comment before the
+        // local-part is valid and stripped from the semantic value. Combined
+        // here with obs CFWS between atoms.
+        let p = parse(
             "(leading) user . name@example.com",
             Strictness::Lax,
             false,
             false,
         )
-        .expect_err("leading comment in bare addr-spec must be rejected");
-        assert_eq!(e.kind(), &ErrorKind::InvalidLocalPartChar { ch: '(' });
+        .unwrap_or_else(|e| panic!("leading comment must be accepted: {e}"));
+        assert_eq!(p.local_part_str(), "user.name");
+        assert_eq!(p.domain_str(), "example.com");
     }
 
     #[test]
@@ -1216,5 +1269,184 @@ mod tests {
             1,
             "backtracked comment must not be duplicated"
         );
+    }
+
+    // ── Leading CFWS before local-part (RFC 5322 dot-atom = [CFWS] ...) ──
+
+    #[test]
+    fn leading_comment_accepted_standard_and_lax() {
+        for strictness in [Strictness::Standard, Strictness::Lax] {
+            let p = parse("(comment)jane.smith@example.com", strictness, false, false)
+                .unwrap_or_else(|e| panic!("{strictness:?}: leading comment must parse: {e}"));
+            assert_eq!(p.local_part_str(), "jane.smith");
+            assert_eq!(p.domain_str(), "example.com");
+        }
+    }
+
+    #[test]
+    fn leading_comment_in_angle_addr() {
+        let p = parse(
+            "<(comment)user@example.com>",
+            Strictness::Standard,
+            false,
+            false,
+        )
+        .unwrap_or_else(|e| panic!("leading comment in angle-addr must parse: {e}"));
+        assert_eq!(p.local_part_str(), "user");
+    }
+
+    #[test]
+    fn strict_still_rejects_leading_comment() {
+        let e = parse(
+            "(comment)user@example.com",
+            Strictness::Strict,
+            false,
+            false,
+        )
+        .expect_err("Strict must reject leading comment");
+        assert_eq!(e.kind(), &ErrorKind::InvalidLocalPartChar { ch: '(' });
+    }
+
+    #[test]
+    fn comment_only_local_part_is_empty() {
+        let e = parse("(comment)@example.com", Strictness::Lax, false, false)
+            .expect_err("comment-only local part must be rejected");
+        assert_eq!(e.kind(), &ErrorKind::EmptyLocalPart);
+    }
+
+    // ── CR/LF are not strippable whitespace (header-injection hardening) ──
+
+    #[test]
+    fn rejects_bare_trailing_lf() {
+        for input in ["test@iana.org\n", "test@iana.org\r", "test@iana.org\r\n"] {
+            assert!(
+                parse(input, Strictness::Lax, false, false).is_err(),
+                "must reject trailing bare CR/LF: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_bare_leading_cr_lf() {
+        for input in ["\rtest@iana.org", "\ntest@iana.org", "\r\ntest@iana.org"] {
+            assert!(
+                parse(input, Strictness::Lax, false, false).is_err(),
+                "must reject leading bare CR/LF: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_bare_cr_in_comment() {
+        // A bare CR inside a comment is not valid FWS.
+        let e = parse("test@iana.org(\r)", Strictness::Lax, false, false)
+            .expect_err("bare CR in comment must be rejected");
+        assert!(matches!(e.kind(), ErrorKind::Unexpected { .. }));
+    }
+
+    #[test]
+    fn accepts_valid_folding_whitespace() {
+        // FWS = CRLF followed by WSP — valid leading and trailing.
+        let leading = parse(" \r\n test@iana.org", Strictness::Lax, false, false)
+            .unwrap_or_else(|e| panic!("leading FWS must parse: {e}"));
+        assert_eq!(leading.local_part_str(), "test");
+
+        let trailing = parse("test@iana.org \r\n ", Strictness::Lax, false, false)
+            .unwrap_or_else(|e| panic!("trailing FWS must parse: {e}"));
+        assert_eq!(trailing.domain_str(), "iana.org");
+    }
+
+    #[test]
+    fn accepts_trailing_and_leading_space() {
+        // Plain leading/trailing spaces are CFWS, accepted in Standard/Lax.
+        assert!(parse(" test@iana.org", Strictness::Standard, false, false).is_ok());
+        assert!(parse("test@iana.org ", Strictness::Standard, false, false).is_ok());
+    }
+
+    // ── Address-literal validation (RFC 5321 §4.1.3) ──
+
+    fn parse_lit(input: &str) -> Result<Parsed<'_>, Error> {
+        // Domain literals require allow_domain_literal = true.
+        parse(input, Strictness::Lax, false, true)
+    }
+
+    #[test]
+    fn accepts_valid_ipv4_literal() {
+        let p = parse_lit("test@[255.255.255.255]").unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(p.domain_str(), "[255.255.255.255]");
+    }
+
+    #[test]
+    fn accepts_valid_ipv6_literal() {
+        for v6 in [
+            "test@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888]",
+            "test@[IPv6:1111:2222:3333:4444:5555::8888]",
+            "test@[IPv6:::]",
+            "test@[IPv6:1111:2222:3333:4444::255.255.255.255]",
+        ] {
+            assert!(parse_lit(v6).is_ok(), "valid IPv6 literal must parse: {v6}");
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_ip_literal() {
+        for bad in [
+            "test@[255.255.255]",                                  // 3 octets
+            "test@[255.255.255.256]",                              // octet > 255
+            "test@[IPv6:1111:2222:3333:4444:5555:6666:7777]",      // 7 groups
+            "test@[IPv6:1111:2222:3333:4444:5555:6666:7777:888G]", // bad hex
+            "test@[IPv6:1::2:]",                                   // trailing colon
+            "test@[RFC-5322-domain-literal]",                      // general literal
+        ] {
+            let e = parse_lit(bad).expect_err(&format!("must reject: {bad}"));
+            assert_eq!(
+                e.kind(),
+                &ErrorKind::InvalidAddressLiteral,
+                "wrong error for {bad}"
+            );
+        }
+    }
+
+    // ── obs-qp / obs-qtext (Lax only) ──
+
+    #[test]
+    fn lax_accepts_obs_qtext_and_obs_qp() {
+        // Control chars (obs-NO-WS-CTL) in qtext and after a quoted-pair are
+        // valid in Lax mode.
+        for input in [
+            "\"\u{07}\"@iana.org",   // obs-qtext BEL
+            "\"\u{7f}\"@iana.org",   // obs-qtext DEL
+            "\"\\\u{00}\"@iana.org", // obs-qp NUL
+            "\"\\\u{0a}\"@iana.org", // obs-qp LF
+        ] {
+            assert!(
+                parse(input, Strictness::Lax, false, false).is_ok(),
+                "Lax must accept obs-qp/qtext: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn standard_rejects_obs_qtext() {
+        // Standard (non-obsolete) mode must reject control chars in qtext.
+        let e = parse("\"\u{07}\"@iana.org", Strictness::Standard, false, false)
+            .expect_err("Standard must reject obs-qtext");
+        assert_eq!(e.kind(), &ErrorKind::InvalidLocalPartChar { ch: '\u{07}' });
+    }
+
+    #[test]
+    fn rejects_quoted_pair_of_non_ascii() {
+        // RFC 6531 puts UTF-8 directly in qtext; escaping it via quoted-pair is
+        // invalid. Standard reports it directly as an invalid quoted-pair.
+        let e = parse(
+            "\"test\\\u{a9}\"@iana.org",
+            Strictness::Standard,
+            false,
+            false,
+        )
+        .expect_err("quoted-pair of non-ASCII must be rejected");
+        assert_eq!(e.kind(), &ErrorKind::InvalidQuotedPair);
+        // Lax also rejects it (after backtracking the obs-local-part attempt).
+        assert!(parse("\"test\\\u{a9}\"@iana.org", Strictness::Lax, false, false).is_err());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1345,6 +1345,14 @@ mod tests {
     }
 
     #[test]
+    fn comment_may_contain_folding_whitespace() {
+        // A comment may fold across lines: CRLF + WSP is valid FWS inside it.
+        let p = parse("(a\r\n b)test@iana.org", Strictness::Lax, false, false)
+            .unwrap_or_else(|e| panic!("folded comment must parse: {e}"));
+        assert_eq!(p.local_part_str(), "test");
+    }
+
+    #[test]
     fn accepts_valid_folding_whitespace() {
         // FWS = CRLF followed by WSP — valid leading and trailing.
         let leading = parse(" \r\n test@iana.org", Strictness::Lax, false, false)
@@ -1404,7 +1412,32 @@ mod tests {
                 &ErrorKind::InvalidAddressLiteral,
                 "wrong error for {bad}"
             );
+            assert!(
+                e.to_string().contains("address literal"),
+                "unexpected Display for {bad}: {e}"
+            );
         }
+    }
+
+    #[test]
+    fn parse_domain_literal_requires_open_bracket() {
+        // Defensive contract: the helper errors if called without a leading '['
+        // (callers only invoke it after peeking '[').
+        let mut parser = Parser::new("nope");
+        assert_eq!(
+            parse_domain_literal(&mut parser).unwrap_err().kind(),
+            &ErrorKind::UnterminatedDomainLiteral
+        );
+    }
+
+    #[test]
+    fn is_qtext_excludes_quote_and_backslash() {
+        // '"' and '\\' are never qtext even though '"' is printable ASCII —
+        // they are structural delimiters handled before is_qtext is consulted.
+        assert!(!is_qtext('"', false));
+        assert!(!is_qtext('"', true));
+        assert!(!is_qtext('\\', true));
+        assert!(is_qtext('a', false));
     }
 
     // ── obs-qp / obs-qtext (Lax only) ──

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -63,11 +63,6 @@ impl Span {
     pub fn as_str<'a>(&self, input: &'a str) -> &'a str {
         &input[self.start..self.end]
     }
-
-    #[allow(dead_code)]
-    pub fn len(&self) -> usize {
-        self.end - self.start
-    }
 }
 
 /// Parser state: tracks current position in the input.
@@ -161,15 +156,12 @@ pub(crate) fn parse(
         None
     };
 
+    // `is_angle` is set only when '<' is the current character: the display-name
+    // parsers stop exactly at it, and the bare case tests `peek() == '<'`. So the
+    // opening bracket is always present and consumed here.
     let is_angle = display_name.is_some() || parser.peek() == Some('<');
     if is_angle {
-        // Skip optional CFWS before <
-        skip_cfws(&mut parser, 0);
-        if !parser.eat('<') {
-            return Err(parser.error(ErrorKind::Unexpected {
-                ch: parser.peek().unwrap_or('\0'),
-            }));
-        }
+        parser.eat('<');
     }
 
     // Parse addr-spec: local-part "@" domain.
@@ -305,15 +297,11 @@ fn parse_local_part(
         // followed by optional "." word segments.
     }
 
-    // dot-atom (or obs-local-part if Lax)
+    // dot-atom (or obs-local-part if Lax). parse_dot_atom_local always consumes
+    // at least one token or returns an error, so the span is never empty here.
     let clean = parse_dot_atom_local(parser, allow_obs)?;
 
-    let end = parser.pos;
-    if end == start {
-        return Err(parser.error(ErrorKind::EmptyLocalPart));
-    }
-
-    Ok((Span::new(start, end), clean))
+    Ok((Span::new(start, parser.pos), clean))
 }
 
 /// Parse dot-atom for local-part: `atext+ ("." atext+)*`.
@@ -486,16 +474,12 @@ fn parse_domain(
         return Ok((Span::new(start, parser.pos), None));
     }
 
-    // dot-atom domain
+    // dot-atom domain. parse_dot_atom_domain parses at least one label or
+    // returns an error, so the span is never empty here.
     let allow_obs = matches!(strictness, Strictness::Lax);
     let clean = parse_dot_atom_domain(parser, allow_obs)?;
 
-    let end = parser.pos;
-    if end == start {
-        return Err(parser.error(ErrorKind::EmptyDomain));
-    }
-
-    Ok((Span::new(start, end), clean))
+    Ok((Span::new(start, parser.pos), clean))
 }
 
 /// Parse dot-atom for domain: `label ("." label)*` where label avoids leading/trailing hyphen.
@@ -688,11 +672,9 @@ fn try_eat_fws(parser: &mut Parser<'_>) -> bool {
     }
 }
 
-/// Skip CFWS (comments and folding whitespace).
+/// Skip CFWS (comments and folding whitespace). `depth` seeds the comment
+/// nesting counter; recursion is bounded by [`parse_comment`].
 fn skip_cfws(parser: &mut Parser<'_>, depth: usize) {
-    if depth >= MAX_RECURSION_DEPTH {
-        return;
-    }
     loop {
         // Skip whitespace and RFC 5322 Folding White Space (CRLF + WSP).
         loop {
@@ -1481,5 +1463,80 @@ mod tests {
         assert_eq!(e.kind(), &ErrorKind::InvalidQuotedPair);
         // Lax also rejects it (after backtracking the obs-local-part attempt).
         assert!(parse("\"test\\\u{a9}\"@iana.org", Strictness::Lax, false, false).is_err());
+    }
+
+    // ── FWS / recursion / quoted-string edge paths ──
+
+    #[test]
+    fn quoted_string_consumes_consecutive_wsp() {
+        // Two spaces in a row exercise the multi-WSP loop in try_eat_fws.
+        let p = parse("\"a  b\"@example.com", Strictness::Standard, false, false)
+            .unwrap_or_else(|e| panic!("quoted string with double space: {e}"));
+        assert_eq!(p.local_part.as_str(p.input), "\"a  b\"");
+    }
+
+    #[test]
+    fn parse_quoted_string_requires_open_quote() {
+        // Defensive contract: errors when not invoked at a '"'.
+        let mut parser = Parser::new("x");
+        assert_eq!(
+            parse_quoted_string(&mut parser, false).unwrap_err().kind(),
+            &ErrorKind::UnterminatedQuotedString
+        );
+    }
+
+    #[test]
+    fn deeply_nested_comment_is_rejected() {
+        // Comment nesting beyond MAX_RECURSION_DEPTH is rejected (DoS guard).
+        let input = format!(
+            "{}x{}test@iana.org",
+            "(".repeat(MAX_RECURSION_DEPTH + 2),
+            ")".repeat(MAX_RECURSION_DEPTH + 2)
+        );
+        assert!(parse(&input, Strictness::Lax, false, false).is_err());
+    }
+
+    // ── Display-name parsing paths (allow_display_name = true) ──
+
+    #[test]
+    fn quoted_local_part_not_treated_as_display_name() {
+        // A quoted string with no following '<' is the local-part, not a
+        // display name — try_parse_display_name backtracks.
+        let p = parse("\"quoted\"@example.com", Strictness::Standard, true, false)
+            .unwrap_or_else(|e| panic!("quoted local with display_name enabled: {e}"));
+        assert_eq!(p.display_name, None);
+        assert_eq!(p.local_part.as_str(p.input), "\"quoted\"");
+    }
+
+    #[test]
+    fn malformed_quoted_display_name_backtracks() {
+        // An unterminated quoted string in display position backtracks, then
+        // fails as a quoted local-part.
+        let e = parse(
+            "\"unterminated@example.com",
+            Strictness::Standard,
+            true,
+            false,
+        )
+        .expect_err("unterminated quoted must fail");
+        assert_eq!(e.kind(), &ErrorKind::UnterminatedQuotedString);
+    }
+
+    #[test]
+    fn control_char_aborts_display_name_scan() {
+        // A control character aborts the unquoted display-name scan; parsing
+        // then falls back to addr-spec and rejects the control char.
+        let e = parse("\u{01}user@example.com", Strictness::Standard, true, false)
+            .expect_err("control char must be rejected");
+        assert_eq!(e.kind(), &ErrorKind::InvalidLocalPartChar { ch: '\u{01}' });
+    }
+
+    #[test]
+    fn unquoted_text_without_angle_is_not_display_name() {
+        // Unquoted text reaching end-of-input with no '<' is not a display
+        // name; it is parsed as an addr-spec, which here lacks '@'.
+        let e = parse("plainname", Strictness::Standard, true, false)
+            .expect_err("bare text without '@' must fail");
+        assert_eq!(e.kind(), &ErrorKind::MissingAtSign);
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1540,4 +1540,36 @@ mod tests {
             .expect_err("bare text without '@' must fail");
         assert_eq!(e.kind(), &ErrorKind::MissingAtSign);
     }
+
+    #[test]
+    fn leading_cfws_before_quoted_display_name() {
+        // A leading space (CFWS) before a quoted display name must not divert
+        // parsing to the unquoted scanner — the display name must be the
+        // unquoted "John Doe", not the raw `"John Doe"` with quotes.
+        let p = parse(
+            " \"John Doe\" <user@example.com>",
+            Strictness::Standard,
+            true,
+            false,
+        )
+        .unwrap_or_else(|e| panic!("leading CFWS + quoted display name: {e}"));
+        assert_eq!(p.display_name.map(|s| s.as_str(p.input)), Some("John Doe"));
+        assert_eq!(p.local_part.as_str(p.input), "user");
+    }
+
+    #[test]
+    fn ipv6_address_literal_tag_is_case_insensitive() {
+        // RFC ABNF string literals are case-insensitive, so the `IPv6:` tag may
+        // be written in any case.
+        for input in [
+            "user@[ipv6:::1]",
+            "user@[IPV6:2001:db8::1]",
+            "user@[IPv6:::1]",
+        ] {
+            assert!(
+                parse(input, Strictness::Lax, false, true).is_ok(),
+                "case-insensitive IPv6 tag must parse: {input}"
+            );
+        }
+    }
 }

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -1,0 +1,176 @@
+//! RFC conformance test against the isEmail test suite
+//! ([dominicsayers/isemail](https://github.com/dominicsayers/isemail), v3.05).
+//!
+//! isEmail assigns every address a *category* on a severity ladder:
+//!
+//! ```text
+//! VALID < DNSWARN < RFC5321 < CFWS < DEPREC < RFC5322 < ERR
+//! ```
+//!
+//! We map each rung onto our [`Strictness`] model. The conformance run uses the
+//! most-permissive *valid* configuration (Lax + domain literals + single-label
+//! domains) and asserts that it accepts everything up to and including DEPREC
+//! (structurally valid, possibly obsolete syntax) and rejects RFC5322 and ERR:
+//!
+//! - **RFC5322** category = valid only under the loosest reading: over-length
+//!   addresses, malformed IP literals (`[IPv6:1::2:]`), and non-IP general
+//!   domain literals (`[RFC-5322-domain-literal]`). A practical validator
+//!   rejects these, so we do too.
+//! - **ERR** = unparseable.
+//!
+//! Any mismatch must be listed in [`KNOWN_DIVERGENCES`] with a reason, otherwise
+//! the test fails — this catches regressions while documenting the handful of
+//! intentional or in-flight differences.
+
+use std::collections::BTreeMap;
+
+use structured_email_address::{Config, EmailAddress, Strictness};
+
+const SUITE: &str = include_str!("isemail_tests.xml");
+
+/// Highest ladder rank our Lax-permissive parse is expected to accept.
+/// DEPREC (4) and below = accept; RFC5322 (5) and ERR (6) = reject.
+const ACCEPT_MAX_RANK: u8 = 4;
+
+/// Categories the issue's acceptance criterion gates on (≥98% pass rate).
+const TARGET_CATEGORIES: &[&str] = &[
+    "ISEMAIL_VALID_CATEGORY",
+    "ISEMAIL_RFC5321",
+    "ISEMAIL_RFC5322",
+];
+
+/// Cases where our result intentionally differs from the isEmail expectation,
+/// each with a justification. Anything not listed here that diverges fails the
+/// test as a regression.
+///
+/// Currently empty: we match all 164 cases of the v3.05 suite under the
+/// Lax-permissive mapping. Add an entry here (with a reason) only for a
+/// deliberate, documented divergence.
+const KNOWN_DIVERGENCES: &[(u32, &str)] = &[];
+
+/// Severity rank of an isEmail category (lower = more valid).
+fn rank(category: &str) -> u8 {
+    match category {
+        "ISEMAIL_VALID_CATEGORY" => 0,
+        "ISEMAIL_DNSWARN" => 1,
+        "ISEMAIL_RFC5321" => 2,
+        "ISEMAIL_CFWS" => 3,
+        "ISEMAIL_DEPREC" => 4,
+        "ISEMAIL_RFC5322" => 5,
+        "ISEMAIL_ERR" => 6,
+        other => panic!("unknown isEmail category: {other}"),
+    }
+}
+
+/// isEmail encodes control characters as the Unicode "control picture" glyphs
+/// (U+2400 + ASCII position) so they survive in XML. Map them back to the real
+/// control characters before feeding the address to the parser.
+fn decode_controls(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            let cp = c as u32;
+            match cp {
+                0x2400..=0x241F => char::from_u32(cp - 0x2400).unwrap_or(c),
+                0x2420 => ' ',
+                0x2421 => '\u{7f}',
+                _ => c,
+            }
+        })
+        .collect()
+}
+
+fn child_text<'a>(node: &roxmltree::Node<'a, '_>, tag: &str) -> &'a str {
+    node.children()
+        .find(|n| n.has_tag_name(tag))
+        .and_then(|n| n.text())
+        .unwrap_or("")
+}
+
+#[test]
+fn isemail_conformance() {
+    let cfg = Config::builder()
+        .strictness(Strictness::Lax)
+        .allow_domain_literal()
+        .allow_single_label_domain()
+        .build();
+
+    let doc = roxmltree::Document::parse(SUITE).expect("isemail_tests.xml must parse");
+
+    // (pass, total) per category.
+    let mut per_cat: BTreeMap<&str, (u32, u32)> = BTreeMap::new();
+    let mut divergences: Vec<(u32, String, String, bool, Option<String>)> = Vec::new();
+
+    for node in doc.descendants().filter(|n| n.has_tag_name("test")) {
+        let id: u32 = node
+            .attribute("id")
+            .expect("test must have id")
+            .parse()
+            .expect("id must be numeric");
+        let address = decode_controls(child_text(&node, "address"));
+        let category = child_text(&node, "category");
+        assert!(!category.is_empty(), "#{id} missing category");
+
+        let expect_accept = rank(category) <= ACCEPT_MAX_RANK;
+        let result = EmailAddress::parse_with(&address, &cfg);
+        let got_accept = result.is_ok();
+
+        let entry = per_cat.entry(category).or_default();
+        entry.1 += 1;
+        if got_accept == expect_accept {
+            entry.0 += 1;
+        } else {
+            let err = result.err().map(|e| e.to_string());
+            divergences.push((id, address, category.to_string(), expect_accept, err));
+        }
+    }
+
+    // Per-category report.
+    eprintln!("\nisEmail conformance (Lax-permissive config):");
+    for (cat, (pass, total)) in &per_cat {
+        eprintln!("  {cat:<24} {pass:>3}/{total:<3}");
+    }
+
+    // Classify divergences against the allowlist.
+    let mut unexpected = Vec::new();
+    if !divergences.is_empty() {
+        eprintln!("\ndivergences:");
+    }
+    for (id, addr, cat, expect_accept, err) in &divergences {
+        let reason = KNOWN_DIVERGENCES
+            .iter()
+            .find(|(kid, _)| kid == id)
+            .map(|(_, r)| *r);
+        eprintln!(
+            "  #{id} [{cat}] expected={} got={} addr={addr:?}{} :: {}",
+            if *expect_accept { "accept" } else { "reject" },
+            if err.is_some() { "reject" } else { "accept" },
+            err.as_deref()
+                .map(|e| format!(" ({e})"))
+                .unwrap_or_default(),
+            reason.unwrap_or("UNEXPECTED — regression"),
+        );
+        if reason.is_none() {
+            unexpected.push(*id);
+        }
+    }
+
+    assert!(
+        unexpected.is_empty(),
+        "unexpected conformance divergences (not in KNOWN_DIVERGENCES): {unexpected:?}"
+    );
+
+    // Acceptance gate: ≥98% on VALID + RFC5321 + RFC5322.
+    let (mut pass, mut total) = (0u32, 0u32);
+    for cat in TARGET_CATEGORIES {
+        let (p, t) = per_cat.get(*cat).copied().unwrap_or((0, 0));
+        pass += p;
+        total += t;
+    }
+    let rate = f64::from(pass) / f64::from(total);
+    eprintln!("\ntarget categories: {pass}/{total} = {:.1}%", rate * 100.0);
+    assert!(
+        rate >= 0.98,
+        "target pass rate {:.1}% < 98% ({pass}/{total})",
+        rate * 100.0
+    );
+}

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -94,7 +94,8 @@ fn isemail_conformance() {
         .allow_single_label_domain()
         .build();
 
-    let doc = roxmltree::Document::parse(SUITE).expect("isemail_tests.xml must parse");
+    let doc = roxmltree::Document::parse(SUITE)
+        .unwrap_or_else(|e| panic!("isemail_tests.xml must parse: {e}"));
 
     // (pass, total) per category.
     let mut per_cat: BTreeMap<&str, (u32, u32)> = BTreeMap::new();
@@ -103,9 +104,9 @@ fn isemail_conformance() {
     for node in doc.descendants().filter(|n| n.has_tag_name("test")) {
         let id: u32 = node
             .attribute("id")
-            .expect("test must have id")
+            .unwrap_or_else(|| panic!("test must have id"))
             .parse()
-            .expect("id must be numeric");
+            .unwrap_or_else(|e| panic!("id must be numeric: {e}"));
         let address = decode_controls(child_text(&node, "address"));
         let category = child_text(&node, "category");
         assert!(!category.is_empty(), "#{id} missing category");

--- a/tests/isemail_tests.xml
+++ b/tests/isemail_tests.xml
@@ -1,0 +1,1226 @@
+<?xml version="1.0"?>
+<!--
+Notes
+.....
+ 1. To test email addresses that include ASCII control characters (ASCII
+    positions < 32), put a Unicode entity in this data. This is because XML
+    doesn't like storing &#x00;. The Unicode entity you should use
+    is &#x2400; + the ASCII position. E.g to test a BEL character (ASCII
+    position 7), put a &#x2407; in this data. This also enables the control
+    characters to be made visible in your output because the Unicode characters
+    &#x2400; onwards are 'SYMBOL FOR xxx'. In other words &#x2407; will look
+    like BEL in your output.
+
+ 2. Certain outcomes are impossible to test since they imply another, higher
+    order, outcome also. These are:
+
+    ISEMAIL_RFC5322_DOMLIT_OBSDTEXT
+    This implies that the domain literal cannot be a valid RFC 5321 address
+    literal. This issue outranks the fact that the token is also obs-dtext.
+
+If you update these tests, don't forget to change the actual version number
+attribute in the <tests> element below!
+
+Date       Tests        Version Notes
+.......... ............ ....... ...............................................
+2010-10-18 #1-#279      3.0	New schema designed to enhance fault
+				identification.
+2011-05-23 #32		3.02	Changed domain to c dash dash n.com because
+				g dash dash a.com no longer has an MX record.
+2011-07-14 All		3.04	Changed my link to https://isemail.info
+2013-11-29 #71		3.05	Changed ISEMAIL_RFC5321 to ISEMAIL_DEPREC
+-->
+<tests version="3.05">
+	<description>
+		<p><strong>New test set</strong></p>
+		<p>This test set is designed to replace and extend the coverage of the original set but with fewer tests.</p>
+		<p>Thanks to Michael Rushton (michael@squiloople.com) for starting this work and contributing tests 1-100</p>
+	</description>
+	<test id="1">
+		<address/>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_NODOMAIN</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="2">
+		<address>test</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_NODOMAIN</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="3">
+		<address>@</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_NOLOCALPART</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="4">
+		<address>test@</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_NODOMAIN</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="5">
+		<address>test@io</address>
+		<comment>io. currently has an MX-record (Feb 2011). Some DNS setups seem to find it, some don't. If you don't see the MX for io. then try setting your DNS server to 8.8.8.8 (the Google DNS server)</comment>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="6">
+		<address>@io</address>
+		<comment>io. currently has an MX-record (Feb 2011)</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_NOLOCALPART</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="7">
+		<address>@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_NOLOCALPART</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="8">
+		<address>test@iana.org</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="9">
+		<address>test@nominet.org.uk</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="10">
+		<address>test@about.museum</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="11">
+		<address>a@iana.org</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="12">
+		<address>test@e.com</address>
+		<category>ISEMAIL_DNSWARN</category>
+		<diagnosis>ISEMAIL_DNSWARN_NO_RECORD</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="13">
+		<address>test@iana.a</address>
+		<category>ISEMAIL_DNSWARN</category>
+		<diagnosis>ISEMAIL_DNSWARN_NO_RECORD</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="14">
+		<address>test.test@iana.org</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="15">
+		<address>.test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_DOT_START</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="16">
+		<address>test.@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_DOT_END</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="17">
+		<address>test..iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_CONSECUTIVEDOTS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="18">
+		<address>test_exa-mple.com</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_NODOMAIN</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="19">
+		<address>!#$%&amp;`*+/=?^`{|}~@iana.org</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="20">
+		<address>test\@test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="21">
+		<address>123@iana.org</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="22">
+		<address>test@123.com</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="23">
+		<address>test@iana.123</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_TLDNUMERIC</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="24">
+		<address>test@255.255.255.255</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_TLDNUMERIC</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="25">
+		<address>abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="26">
+		<address>abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklmn@iana.org</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_LOCAL_TOOLONG</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="27">
+		<address>test@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.com</address>
+		<category>ISEMAIL_DNSWARN</category>
+		<diagnosis>ISEMAIL_DNSWARN_NO_RECORD</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="28">
+		<address>test@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm.com</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_LABEL_TOOLONG</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="29">
+		<address>test@mason-dixon.com</address>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="30">
+		<address>test@-iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_DOMAINHYPHENSTART</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="31">
+		<address>test@iana-.com</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_DOMAINHYPHENEND</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="32">
+		<address>test@c--n.com</address>
+		<comment>c--n.com currently has an MX-record (May 2011)</comment>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="33">
+		<address>test@iana.co-uk</address>
+		<category>ISEMAIL_DNSWARN</category>
+		<diagnosis>ISEMAIL_DNSWARN_NO_RECORD</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="34">
+		<address>test@.iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_DOT_START</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="35">
+		<address>test@iana.org.</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_DOT_END</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="36">
+		<address>test@iana..com</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_CONSECUTIVEDOTS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="37">
+		<address>a@a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v</address>
+		<category>ISEMAIL_DNSWARN</category>
+		<diagnosis>ISEMAIL_DNSWARN_NO_RECORD</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="38">
+		<address>abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghi</address>
+		<category>ISEMAIL_DNSWARN</category>
+		<diagnosis>ISEMAIL_DNSWARN_NO_RECORD</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="39">
+		<address>abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_TOOLONG</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="40">
+		<address>a@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefg.hij</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_TOOLONG</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="41">
+		<address>a@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefg.hijk</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAIN_TOOLONG</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="42">
+		<address>"test"@iana.org</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_QUOTEDSTRING</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="43">
+		<address>""@iana.org</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_QUOTEDSTRING</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="44">
+		<address>"""@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="45">
+		<address>"\a"@iana.org</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_QUOTEDSTRING</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="46">
+		<address>"\""@iana.org</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_QUOTEDSTRING</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="47">
+		<address>"\"@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDQUOTEDSTR</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="48">
+		<address>"\\"@iana.org</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_QUOTEDSTRING</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="49">
+		<address>test"@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="50">
+		<address>"test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDQUOTEDSTR</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="51">
+		<address>"test"test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_ATEXT_AFTER_QS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="52">
+		<address>test"text"@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="53">
+		<address>"test""test"@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="54">
+		<address>"test"."test"@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_LOCALPART</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="55">
+		<address>"test\ test"@iana.org</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_QUOTEDSTRING</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="56">
+		<address>"test".test@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_LOCALPART</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="57">
+		<address>"test&#x2400;"@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_QTEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="58">
+		<address>"test\&#x2400;"@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_QP</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="59">
+		<address>"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghj"@iana.org</address>
+		<comment>Quotes are still part of the length restriction</comment>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_LOCAL_TOOLONG</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="60">
+		<address>"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefg\h"@iana.org</address>
+		<comment>Quoted pair is still part of the length restriction</comment>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_LOCAL_TOOLONG</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="61">
+		<address>test@[255.255.255.255]</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_ADDRESSLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="62">
+		<address>test@a[255.255.255.255]</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="63">
+		<address>test@[255.255.255]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAINLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="64">
+		<address>test@[255.255.255.255.255]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAINLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="65">
+		<address>test@[255.255.255.256]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAINLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="66">
+		<address>test@[1111:2222:3333:4444:5555:6666:7777:8888]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAINLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="67">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666:7777]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_GRPCOUNT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="68">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888]</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_ADDRESSLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="69">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666:7777:8888:9999]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_GRPCOUNT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="70">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666:7777:888G]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_BADCHAR</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="71">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666::8888]</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_RFC5321_IPV6DEPRECATED</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="72">
+		<address>test@[IPv6:1111:2222:3333:4444:5555::8888]</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_ADDRESSLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="73">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666::7777:8888]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_MAXGRPS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="74">
+		<address>test@[IPv6::3333:4444:5555:6666:7777:8888]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_COLONSTRT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="75">
+		<address>test@[IPv6:::3333:4444:5555:6666:7777:8888]</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_ADDRESSLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="76">
+		<address>test@[IPv6:1111::4444:5555::8888]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_2X2XCOLON</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="77">
+		<address>test@[IPv6:::]</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_ADDRESSLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="78">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:255.255.255.255]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_GRPCOUNT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="79">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666:255.255.255.255]</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_ADDRESSLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="80">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666:7777:255.255.255.255]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_GRPCOUNT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="81">
+		<address>test@[IPv6:1111:2222:3333:4444::255.255.255.255]</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_ADDRESSLITERAL</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="82">
+		<address>test@[IPv6:1111:2222:3333:4444:5555:6666::255.255.255.255]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_MAXGRPS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="83">
+		<address>test@[IPv6:1111:2222:3333:4444:::255.255.255.255]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_2X2XCOLON</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="84">
+		<address>test@[IPv6::255.255.255.255]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_COLONSTRT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="85">
+		<address> test @iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_CFWS_NEAR_AT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="86">
+		<address>test@ iana .com</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_CFWS_NEAR_AT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="87">
+		<address>test . test@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_FWS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="88">
+		<address>&#x240D;&#x240A; test@iana.org</address>
+		<comment>FWS</comment>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_FWS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="89">
+		<address>&#x240D;&#x240A; &#x240D;&#x240A; test@iana.org</address>
+		<comment>FWS with one line composed entirely of WSP -- only allowed as obsolete FWS (someone might allow only non-obsolete FWS)</comment>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_FWS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="90">
+		<address>(comment)test@iana.org</address>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_COMMENT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="91">
+		<address>((comment)test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDCOMMENT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="92">
+		<address>(comment(comment))test@iana.org</address>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_COMMENT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="93">
+		<address>test@(comment)iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_CFWS_NEAR_AT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="94">
+		<address>test(comment)test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_ATEXT_AFTER_CFWS</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="95">
+		<address>test@(comment)[255.255.255.255]</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_CFWS_NEAR_AT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="96">
+		<address>(comment)abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghiklm@iana.org</address>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_COMMENT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="97">
+		<address>test@(comment)abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghikl.com</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_CFWS_NEAR_AT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="98">
+		<address>(comment)test@abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghik.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghik.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstu</address>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_COMMENT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="99">
+		<address>test@iana.org&#x240A;</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="100">
+		<address>test@xn--hxajbheg2az3al.xn--jxalpdlp</address>
+		<comment>A valid IDN from ICANN's <a href="https://idn.icann.org/#The_example.test_names">IDN TLD evaluation gateway</a></comment>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="101">
+		<address>xn--test@iana.org</address>
+		<comment>RFC 3490: "unless the
+   email standards are revised to invite the use of IDNA for local
+   parts, a domain label that holds the local part of an email address
+   SHOULD NOT begin with the ACE prefix, and even if it does, it is to
+   be interpreted literally as a local part that happens to begin with
+   the ACE prefix"</comment>
+		<category>ISEMAIL_VALID_CATEGORY</category>
+		<diagnosis>ISEMAIL_VALID</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="102">
+		<address>test@iana.org-</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_DOMAINHYPHENEND</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="103">
+		<address>"test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDQUOTEDSTR</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="104">
+		<address>(test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDCOMMENT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="105">
+		<address>test@(iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDCOMMENT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="106">
+		<address>test@[1.2.3.4</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDDOMLIT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="107">
+		<address>"test\"@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDQUOTEDSTR</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="108">
+		<address>(comment\)test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDCOMMENT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="109">
+		<address>test@iana.org(comment\)</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDCOMMENT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="110">
+		<address>test@iana.org(comment\</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_BACKSLASHEND</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="112">
+		<address>test@[RFC-5322-domain-literal]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAINLITERAL</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="113">
+		<address>test@[RFC-5322]-domain-literal]</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_ATEXT_AFTER_DOMLIT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="114">
+		<address>test@[RFC-5322-[domain-literal]</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_DTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="115">
+		<address>test@[RFC-5322-\&#x2407;-domain-literal]</address>
+		<comment>obs-dtext <strong>and</strong> obs-qp</comment>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMLIT_OBSDTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="116">
+		<address>test@[RFC-5322-\&#x2409;-domain-literal]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMLIT_OBSDTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="117">
+		<address>test@[RFC-5322-\]-domain-literal]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMLIT_OBSDTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="118">
+		<address>test@[RFC-5322-domain-literal\]</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_UNCLOSEDDOMLIT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="119">
+		<address>test@[RFC-5322-domain-literal\</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_BACKSLASHEND</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="120">
+		<address>test@[RFC 5322 domain literal]</address>
+		<comment>Spaces are FWS in a domain literal</comment>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAINLITERAL</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="121">
+		<address>test@[RFC-5322-domain-literal] (comment)</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAINLITERAL</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="122">
+		<address>@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="123">
+		<address>test@.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="124">
+		<address>""@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_QTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="125">
+		<address>"\"@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_QP</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="126">
+		<address>()test@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_CTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="127">
+		<address>test@iana.org&#x240D;</address>
+		<comment>No LF after the CR</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_CR_NO_LF</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="128">
+		<address>&#x240D;test@iana.org</address>
+		<comment>No LF after the CR</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_CR_NO_LF</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="129">
+		<address>"&#x240D;test"@iana.org</address>
+		<comment>No LF after the CR</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_CR_NO_LF</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="130">
+		<address>(&#x240D;)test@iana.org</address>
+		<comment>No LF after the CR</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_CR_NO_LF</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="131">
+		<address>test@iana.org(&#x240D;)</address>
+		<comment>No LF after the CR</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_CR_NO_LF</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="132">
+		<address>&#x240A;test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Michael Rushton</source>
+		<sourcelink>https://squiloople.com/tag/email/</sourcelink>
+	</test>
+	<test id="133">
+		<address>"&#x240A;"@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_QTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="134">
+		<address>"\&#x240A;"@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_QP</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="135">
+		<address>(&#x240A;)test@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_CTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="136">
+		<address>&#x2407;@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="137">
+		<address>test@&#x2407;.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_ATEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="138">
+		<address>"&#x2407;"@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_QTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="139">
+		<address>"\&#x2407;"@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_QP</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="140">
+		<address>(&#x2407;)test@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_CTEXT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="141">
+		<address>&#x240D;&#x240A;test@iana.org</address>
+		<comment>Not FWS because no actual white space</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_END</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="142">
+		<address>&#x240D;&#x240A; &#x240D;&#x240A;test@iana.org</address>
+		<comment>Not obs-FWS because there must be white space on each "fold"</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_END</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="143">
+		<address> &#x240D;&#x240A;test@iana.org</address>
+		<comment>Not FWS because no white space after the fold</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_END</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="144">
+		<address> &#x240D;&#x240A; test@iana.org</address>
+		<comment>FWS</comment>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_FWS</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="145">
+		<address> &#x240D;&#x240A; &#x240D;&#x240A;test@iana.org</address>
+		<comment>Not FWS because no white space after the second fold</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_END</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="146">
+		<address> &#x240D;&#x240A;&#x240D;&#x240A;test@iana.org</address>
+		<comment>Not FWS because no white space after either fold</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_X2</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="147">
+		<address> &#x240D;&#x240A;&#x240D;&#x240A; test@iana.org</address>
+		<comment>Not FWS because no white space after the first fold</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_X2</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="148">
+		<address>test@iana.org&#x240D;&#x240A; </address>
+		<comment>FWS</comment>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_FWS</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="149">
+		<address>test@iana.org&#x240D;&#x240A; &#x240D;&#x240A; </address>
+		<comment>FWS with one line composed entirely of WSP -- only allowed as obsolete FWS (someone might allow only non-obsolete FWS)</comment>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_FWS</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="150">
+		<address>test@iana.org&#x240D;&#x240A;</address>
+		<comment>Not FWS because no actual white space</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_END</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="151">
+		<address>test@iana.org&#x240D;&#x240A; &#x240D;&#x240A;</address>
+		<comment>Not obs-FWS because there must be white space on each "fold"</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_END</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="152">
+		<address>test@iana.org &#x240D;&#x240A;</address>
+		<comment>Not FWS because no white space after the fold</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_END</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="153">
+		<address>test@iana.org &#x240D;&#x240A; </address>
+		<comment>FWS</comment>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_FWS</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="154">
+		<address>test@iana.org &#x240D;&#x240A; &#x240D;&#x240A;</address>
+		<comment>Not FWS because no white space after the second fold</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_END</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="155">
+		<address>test@iana.org &#x240D;&#x240A;&#x240D;&#x240A;</address>
+		<comment>Not FWS because no white space after either fold</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_X2</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="156">
+		<address>test@iana.org &#x240D;&#x240A;&#x240D;&#x240A; </address>
+		<comment>Not FWS because no white space after the first fold</comment>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_FWS_CRLF_X2</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="157">
+		<address> test@iana.org</address>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_FWS</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="158">
+		<address>test@iana.org </address>
+		<category>ISEMAIL_CFWS</category>
+		<diagnosis>ISEMAIL_CFWS_FWS</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="159">
+		<address>test@[IPv6:1::2:]</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_IPV6_COLONEND</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="160">
+		<address>"test\&#xA9;"@iana.org</address>
+		<category>ISEMAIL_ERR</category>
+		<diagnosis>ISEMAIL_ERR_EXPECTING_QPAIR</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="161">
+		<address>test@iana/icann.org</address>
+		<category>ISEMAIL_RFC5322</category>
+		<diagnosis>ISEMAIL_RFC5322_DOMAIN</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="165">
+		<address>test.(comment)test@iana.org</address>
+		<category>ISEMAIL_DEPREC</category>
+		<diagnosis>ISEMAIL_DEPREC_COMMENT</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="166">
+		<address>test@org</address>
+		<category>ISEMAIL_RFC5321</category>
+		<diagnosis>ISEMAIL_RFC5321_TLD</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="167">
+		<address>test@test.com</address>
+		<comment>test.com has an A-record but not an MX-record</comment>
+		<category>ISEMAIL_DNSWARN</category>
+		<diagnosis>ISEMAIL_DNSWARN_NO_MX_RECORD</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+	<test id="168">
+		<address>test@nic.no</address>
+		<comment>nic.no currently has no MX-records or A-records (Feb 2011). If you are seeing an A-record for nic.io then try setting your DNS server to 8.8.8.8 (the Google DNS server) - your DNS server may be faking an A-record (OpenDNS does this, for instance).</comment>
+		<category>ISEMAIL_DNSWARN</category>
+		<diagnosis>ISEMAIL_DNSWARN_NO_RECORD</diagnosis>
+		<source>Dominic Sayers</source>
+		<sourcelink>https://isemail.info</sourcelink>
+	</test>
+</tests>


### PR DESCRIPTION
## Summary

Adds the [isEmail](https://github.com/dominicsayers/isemail) conformance suite (v3.05, 164 edge cases) as a baseline and fixes the parser bugs it surfaced. **All 164 cases pass (100%)**; the issue's target categories (VALID + RFC5321 + RFC5322) are 60/60.

This closes both **#2** (conformance suite) and **#40** (leading comment) — the leading-CFWS handling needed for conformance is the same fix as #40, so it is folded in here and PR #44 is superseded.

## Conformance harness

- `tests/isemail_tests.xml` — the suite, embedded via `include_str!`.
- `tests/conformance.rs` — data-driven test mapping each isEmail category onto our `Strictness` ladder (`VALID < DNSWARN < RFC5321 < CFWS < DEPREC < RFC5322 < ERR`). Decodes the U+2400 control-picture glyphs back to real control chars, runs the most-permissive valid config, and gates on **≥98% for VALID + RFC5321 + RFC5322** plus a *zero-unexpected-divergence* check against a documented allowlist (currently empty — full match).

```
VALID 14/14 · DNSWARN 8/8 · RFC5321 16/16 · CFWS 10/10
DEPREC 20/20 · RFC5322 30/30 · ERR 66/66   →   164/164 (100%)
```

## Parser fixes (surfaced by the suite)

- **Leading `[CFWS]` before the local-part** (RFC 5322 `dot-atom = [CFWS] dot-atom-text [CFWS]`) accepted in Standard/Lax; Strict still rejects. *(this is #40)*
- **Drop `input.trim()`** — bare CR/LF are no longer stripped, so `user@host\n` is now **rejected** (header-injection hardening). Valid folding whitespace (`CRLF + WSP`) is still accepted.
- **Address-literal validation** (RFC 5321 §4.1.3): only a valid IPv4 dotted-quad or `IPv6:`-tagged IPv6 (`core::net`) is accepted; general/malformed `[...]` literals are rejected with the new `ErrorKind::InvalidAddressLiteral`.
- **obs-qp / obs-qtext** (control characters) accepted in quoted strings in Lax.
- **Quoted-pair of non-ASCII rejected** (RFC 6531 keeps UTF-8 directly in qtext).
- **Bare CR/LF inside a comment rejected** (only `CRLF + WSP` is valid FWS).

## Behavior changes

- Domain literals must now be valid IP literals (was: any `dtext`).
- Addresses with bare CR/LF are now rejected (was: silently trimmed/accepted).
- `original()` returns the input untrimmed (doc updated).

## Testing

- `cargo nextest run --all-features` → 98 passed
- `cargo nextest run --no-default-features` → 96 passed
- `cargo test --doc --all-features` → 5 passed
- `cargo clippy --all-targets --all-features -- -D warnings` → clean

Closes #2
Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reject addresses with bare CR/LF and newline sequences that could bypass validation
  * Tightened domain-literal validation: only valid IPv4/IPv6 are accepted; non-IP literals are rejected with a clearer error
  * Improved header-injection hardening by avoiding automatic trimming and tightening comment/CFWS handling
* **Documentation**
  * Updated `original` field documentation to state it is preserved exactly as supplied (not trimmed)
  * Added a **Conformance** section describing validation status against the isEmail v3.05 suite
* **Tests**
  * Added conformance testing against the isEmail v3.05 XML suite and expanded parsing coverage (comments, quoted/display-name behavior, and error expectations)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->