### PR TITLE
feat(deps): migrate PSL to structured-public-domains + cascade releases

### DIFF
--- a/.github/workflows/psl-cascade.yml
+++ b/.github/workflows/psl-cascade.yml
@@ -89,24 +89,44 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "Baseline $BASE_TAG depends on structured-public-domains v$DEP_AT_TAG; target v$VERSION"
 
-      - name: No-op guard
-        id: guard
+      - name: Plan release vs sync
+        id: plan
+        env:
+          BASE_TAG: ${{ steps.resolve.outputs.base_tag }}
+          DEP_AT_TAG: ${{ steps.resolve.outputs.dep_at_tag }}
+          VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           set -euo pipefail
-          if [ "${{ steps.resolve.outputs.dep_at_tag }}" = "${{ steps.resolve.outputs.version }}" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Baseline already depends on v${{ steps.resolve.outputs.version }}; nothing to release."
+          git fetch origin main --quiet
+          # Is the baseline release tag already merged into main?
+          if git merge-base --is-ancestor "$BASE_TAG" origin/main; then
+            on_main=true
           else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+            on_main=false
           fi
+          if [ "$DEP_AT_TAG" != "$VERSION" ]; then
+            # New dependency version → cut a fresh data release, then sync it.
+            mode=release
+          elif [ "$on_main" = "false" ]; then
+            # This dep version was already released, but its tag never reached
+            # main — a prior run failed between tagging and the main sync.
+            # Re-sync the existing tag without cutting another release.
+            mode=sync
+          else
+            mode=noop
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "Mode: $mode (base=$BASE_TAG on_main=$on_main dep@tag=$DEP_AT_TAG target=$VERSION)"
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.guard.outputs.changed == 'true'
+        if: steps.plan.outputs.mode == 'release'
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
-        if: steps.guard.outputs.changed == 'true'
+        if: steps.plan.outputs.mode == 'release'
 
       - name: Cut data release off the last tag
-        if: steps.guard.outputs.changed == 'true'
+        if: steps.plan.outputs.mode == 'release'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BASE_TAG: ${{ steps.resolve.outputs.base_tag }}
@@ -116,9 +136,13 @@ jobs:
           git config user.name "sw-release-bot[bot]"
           git config user.email "sw-release-bot[bot]@users.noreply.github.com"
 
+          # Version-specific branch: a fixed name would collide with the remote
+          # branch left by the previous cascade and be rejected as non-fast-forward.
+          BRANCH="chore/psl-cascade-${VERSION}"
+
           # Branch from the LAST RELEASE so the data release carries no unreleased
           # code that may be sitting on main.
-          git checkout -B chore/psl-cascade "$BASE_TAG"
+          git checkout -B "$BRANCH" "$BASE_TAG"
 
           # Patch-bump our own version from the baseline; point the dependency at
           # the new structured-public-domains release.
@@ -141,7 +165,14 @@ jobs:
           PY
 
           cargo update -p structured-public-domains --precise "$VERSION"
+
+          # Run the same gates CI enforces before publishing: a data bump must
+          # not ship unless clippy and the no-default-features build also pass.
           cargo test --all-features
+          cargo test --no-default-features
+          cargo test --doc --all-features
+          cargo clippy --all-features -- -D warnings
+          cargo clippy --no-default-features -- -D warnings
 
           # Prepend a CHANGELOG entry right after the "## [Unreleased]" marker.
           TODAY=$(date -u +%Y-%m-%d)
@@ -172,7 +203,7 @@ jobs:
 
           # Push branch + tag, then create the release whose `created` event
           # triggers crates.io publishing (release.yml).
-          git push -u origin chore/psl-cascade
+          git push -u origin "$BRANCH"
           git tag "v${NEW}"
           git push origin "v${NEW}"
           gh release create "v${NEW}" --title "v${NEW}" \
@@ -181,17 +212,31 @@ jobs:
           echo "new_version=$NEW" >> "$GITHUB_ENV"
 
       - name: Sync the data release onto main
-        if: steps.guard.outputs.changed == 'true'
+        if: steps.plan.outputs.mode == 'release' || steps.plan.outputs.mode == 'sync'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MODE: ${{ steps.plan.outputs.mode }}
+          BASE_TAG: ${{ steps.resolve.outputs.base_tag }}
           VERSION: ${{ steps.resolve.outputs.version }}
         run: |
           set -euo pipefail
+          BRANCH="chore/psl-cascade-${VERSION}"
+
+          # Resync path: the release tag exists but never reached main (a prior
+          # run failed after tagging). Recreate the branch at the released tag so
+          # the same sync PR can be opened. In 'release' mode the branch was
+          # already pushed by the cut step.
+          if [ "$MODE" = "sync" ]; then
+            git push origin --force "${BASE_TAG}:refs/heads/${BRANCH}"
+          fi
+
           # Bring the released data commit onto main via a MERGE commit (not squash
-          # or cherry-pick): the merge keeps the tagged commit as an ancestor of
-          # main, so release-plz recognises the data version as released and the
-          # next code release's changelog lists only the code — not the data again.
-          gh pr create --base main --head chore/psl-cascade \
+          # or cherry-pick): the merge keeps the tagged commit an ancestor of main,
+          # so release-plz recognises the data version as released and the next
+          # code release's changelog lists only the code — not the data again.
+          # Tolerate an already-open PR from a prior partial run.
+          gh pr create --base main --head "$BRANCH" \
             --title "feat(data): bump PSL data to structured-public-domains v${VERSION}" \
-            --body "Sync of released data v${new_version} onto main."
-          gh pr merge --auto --merge chore/psl-cascade
+            --body "Sync of released PSL data (structured-public-domains v${VERSION}) onto main." \
+            || true
+          gh pr merge --auto --merge "$BRANCH"

--- a/.github/workflows/psl-cascade.yml
+++ b/.github/workflows/psl-cascade.yml
@@ -48,14 +48,22 @@ jobs:
 
       - name: Resolve version and baseline tag
         id: resolve
+        env:
+          # Untrusted input (repository_dispatch payload / manual input): pass via
+          # env, never interpolate into the shell, and validate before any use.
+          VERSION_INPUT: ${{ github.event.client_payload.version || inputs.version }}
         run: |
           set -euo pipefail
-          # New dependency version: from the dispatch payload, or the manual input.
-          VERSION="${{ github.event.client_payload.version || inputs.version }}"
+          VERSION="$VERSION_INPUT"
           if [ -z "$VERSION" ]; then
             echo "No structured-public-domains version provided." >&2
             exit 1
           fi
+          # Accept only a bare semver (x.y.z); reject anything that could inject.
+          printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "Invalid structured-public-domains version: $VERSION" >&2
+            exit 1
+          }
 
           # Highest semver tag (vX.Y.Z) is the baseline a data release is cut from.
           BASE_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)

--- a/.github/workflows/psl-cascade.yml
+++ b/.github/workflows/psl-cascade.yml
@@ -111,13 +111,26 @@ jobs:
           else
             on_main=false
           fi
-          if [ "$DEP_AT_TAG" != "$VERSION" ]; then
-            # New dependency version → cut a fresh data release, then sync it.
+          # Compare versions numerically (both already validated as x.y.z). Only a
+          # strictly-newer dependency cuts a release — a stale/out-of-order dispatch
+          # carrying an OLDER version must not downgrade the dependency.
+          newer=$(python3 - "$DEP_AT_TAG" "$VERSION" <<'PY'
+          import sys
+          cur = tuple(map(int, sys.argv[1].split(".")))
+          req = tuple(map(int, sys.argv[2].split(".")))
+          print("yes" if req > cur else ("equal" if req == cur else "older"))
+          PY
+          )
+          if [ "$newer" = "older" ]; then
+            echo "Requested structured-public-domains v$VERSION is older than baseline v$DEP_AT_TAG; refusing to downgrade." >&2
+            exit 1
+          elif [ "$newer" = "yes" ]; then
+            # Strictly newer dependency → cut a fresh data release, then sync it.
             mode=release
           elif [ "$on_main" = "false" ]; then
-            # This dep version was already released, but its tag never reached
-            # main — a prior run failed between tagging and the main sync.
-            # Re-sync the existing tag without cutting another release.
+            # Same dep version already released, but its tag never reached main —
+            # a prior run failed between tagging and the main sync. Re-sync the
+            # existing tag without cutting another release.
             mode=sync
           else
             mode=noop

--- a/.github/workflows/psl-cascade.yml
+++ b/.github/workflows/psl-cascade.yml
@@ -1,0 +1,189 @@
+name: PSL Cascade
+
+# Receives a PSL data update from structured-public-domains and releases it here
+# as a DATA-ONLY patch, mirroring that crate's own off-tag release behaviour.
+#
+# A data release is cut from the LAST RELEASE TAG, not from main's HEAD, so it
+# can never sweep in unreleased code sitting on main. It contains only the
+# structured-public-domains dependency bump. The data commit is then synced onto
+# main via a MERGE commit; release-plz re-computes the pending code release to
+# stack on top of the new data release (data and code stay on separate version
+# steps).
+#
+# Bootstrap: the baseline tag must already depend on structured-public-domains.
+# Until the code release that introduces that dependency is tagged, this workflow
+# refuses to run (the dependency is absent at the tag — see the guard below).
+#
+# No cancel-in-progress — a run that already tagged/pushed must not be killed.
+concurrency:
+  group: psl-cascade
+
+on:
+  repository_dispatch:
+    types: [psl-updated]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "structured-public-domains version"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  cascade:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token (SW Release Bot)
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0  # full history + tags needed to branch off the last release
+
+      - name: Resolve version and baseline tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          # New dependency version: from the dispatch payload, or the manual input.
+          VERSION="${{ github.event.client_payload.version || inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            echo "No structured-public-domains version provided." >&2
+            exit 1
+          fi
+
+          # Highest semver tag (vX.Y.Z) is the baseline a data release is cut from.
+          BASE_TAG=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          if [ -z "$BASE_TAG" ]; then
+            echo "No release tag found; cannot cut a data release." >&2
+            exit 1
+          fi
+
+          # The baseline must already carry the structured-public-domains dependency.
+          DEP_AT_TAG=$(git show "$BASE_TAG:Cargo.toml" \
+            | grep -E '^structured-public-domains[[:space:]]*=' \
+            | grep -oE 'version = "[^"]+"' | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ -z "$DEP_AT_TAG" ]; then
+            echo "Baseline $BASE_TAG predates the structured-public-domains dependency." >&2
+            echo "Release the code migration first, then re-run this cascade." >&2
+            exit 1
+          fi
+
+          {
+            echo "version=$VERSION"
+            echo "base_tag=$BASE_TAG"
+            echo "dep_at_tag=$DEP_AT_TAG"
+          } >> "$GITHUB_OUTPUT"
+          echo "Baseline $BASE_TAG depends on structured-public-domains v$DEP_AT_TAG; target v$VERSION"
+
+      - name: No-op guard
+        id: guard
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.resolve.outputs.dep_at_tag }}" = "${{ steps.resolve.outputs.version }}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Baseline already depends on v${{ steps.resolve.outputs.version }}; nothing to release."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.guard.outputs.changed == 'true'
+      - uses: Swatinem/rust-cache@v2
+        if: steps.guard.outputs.changed == 'true'
+
+      - name: Cut data release off the last tag
+        if: steps.guard.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BASE_TAG: ${{ steps.resolve.outputs.base_tag }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "sw-release-bot[bot]"
+          git config user.email "sw-release-bot[bot]@users.noreply.github.com"
+
+          # Branch from the LAST RELEASE so the data release carries no unreleased
+          # code that may be sitting on main.
+          git checkout -B chore/psl-cascade "$BASE_TAG"
+
+          # Patch-bump our own version from the baseline; point the dependency at
+          # the new structured-public-domains release.
+          BASE_VER=$(grep -m1 '^version = ' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+          NEW="$(echo "$BASE_VER" | cut -d. -f1).$(echo "$BASE_VER" | cut -d. -f2).$(( $(echo "$BASE_VER" | cut -d. -f3) + 1 ))"
+          python3 - "$VERSION" "$NEW" <<'PY'
+          import re, sys, pathlib
+          dep_ver, own_ver = sys.argv[1], sys.argv[2]
+          p = pathlib.Path("Cargo.toml")
+          t = p.read_text(encoding="utf-8")
+          # Bump the [package] version (first top-level `version = "..."`).
+          t, n = re.subn(r'(?m)^version = "[^"]+"', f'version = "{own_ver}"', t, count=1)
+          assert n == 1, "package version line not found"
+          # Bump the structured-public-domains dependency version in place.
+          t, n = re.subn(
+              r'(structured-public-domains\s*=\s*\{[^}]*?version\s*=\s*")[^"]+(")',
+              rf'\g<1>{dep_ver}\g<2>', t, count=1)
+          assert n == 1, "structured-public-domains dependency line not found"
+          p.write_text(t, encoding="utf-8")
+          PY
+
+          cargo update -p structured-public-domains --precise "$VERSION"
+          cargo test --all-features
+
+          # Prepend a CHANGELOG entry right after the "## [Unreleased]" marker.
+          TODAY=$(date -u +%Y-%m-%d)
+          {
+            echo "## [${NEW}](https://github.com/${GITHUB_REPOSITORY}/compare/${BASE_TAG}...v${NEW}) - ${TODAY}"
+            echo ""
+            echo "### Data"
+            echo ""
+            echo "PSL data: bump structured-public-domains to v${VERSION}."
+          } > /tmp/changelog-entry.md
+          python3 - "$NEW" <<'PY'
+          import sys, pathlib
+          new = sys.argv[1]
+          cl = pathlib.Path("CHANGELOG.md")
+          text = cl.read_text(encoding="utf-8")
+          entry = pathlib.Path("/tmp/changelog-entry.md").read_text(encoding="utf-8")
+          marker = "## [Unreleased]"
+          idx = text.find(marker)
+          if idx == -1:
+              cl.write_text(entry + "\n" + text, encoding="utf-8")
+          else:
+              end = text.find("\n", idx) + 1
+              cl.write_text(text[:end] + "\n" + entry + text[end:], encoding="utf-8")
+          PY
+
+          git add -A
+          git commit -m "feat(data): bump PSL data to structured-public-domains v${VERSION}"
+
+          # Push branch + tag, then create the release whose `created` event
+          # triggers crates.io publishing (release.yml).
+          git push -u origin chore/psl-cascade
+          git tag "v${NEW}"
+          git push origin "v${NEW}"
+          gh release create "v${NEW}" --title "v${NEW}" \
+            --notes "PSL data update: structured-public-domains v${VERSION}"
+
+          echo "new_version=$NEW" >> "$GITHUB_ENV"
+
+      - name: Sync the data release onto main
+        if: steps.guard.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Bring the released data commit onto main via a MERGE commit (not squash
+          # or cherry-pick): the merge keeps the tagged commit as an ancestor of
+          # main, so release-plz recognises the data version as released and the
+          # next code release's changelog lists only the code — not the data again.
+          gh pr create --base main --head chore/psl-cascade \
+            --title "feat(data): bump PSL data to structured-public-domains v${VERSION}" \
+            --body "Sync of released data v${new_version} onto main."
+          gh pr merge --auto --merge chore/psl-cascade

--- a/.github/workflows/psl-cascade.yml
+++ b/.github/workflows/psl-cascade.yml
@@ -73,9 +73,11 @@ jobs:
           fi
 
           # The baseline must already carry the structured-public-domains dependency.
+          # `|| true` keeps `set -o pipefail` from aborting the step when the grep
+          # finds nothing (baseline predates the dependency) so the guard below runs.
           DEP_AT_TAG=$(git show "$BASE_TAG:Cargo.toml" \
             | grep -E '^structured-public-domains[[:space:]]*=' \
-            | grep -oE 'version = "[^"]+"' | head -1 | sed 's/.*"\(.*\)"/\1/')
+            | grep -oE 'version = "[^"]+"' | head -1 | sed 's/.*"\(.*\)"/\1/' || true)
           if [ -z "$DEP_AT_TAG" ]; then
             echo "Baseline $BASE_TAG predates the structured-public-domains dependency." >&2
             echo "Release the code migration first, then re-run this cascade." >&2
@@ -230,6 +232,12 @@ jobs:
           # already pushed by the cut step.
           if [ "$MODE" = "sync" ]; then
             git push origin --force "${BASE_TAG}:refs/heads/${BRANCH}"
+            # If the prior run failed at `gh release create`, the release object
+            # (and thus the crates.io publish) is missing — recreate it so the
+            # tag actually publishes.
+            gh release view "$BASE_TAG" >/dev/null 2>&1 || \
+              gh release create "$BASE_TAG" --title "$BASE_TAG" \
+                --notes "PSL data update: structured-public-domains v${VERSION}"
           fi
 
           # Bring the released data commit onto main via a MERGE commit (not squash

--- a/.github/workflows/psl-cascade.yml
+++ b/.github/workflows/psl-cascade.yml
@@ -45,6 +45,11 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0  # full history + tags needed to branch off the last release
+          # Do not persist the write-capable app token in .git/config: the job
+          # runs cargo (build scripts / proc-macros from dependencies) before any
+          # push, and a malicious one could read a persisted credential. Auth is
+          # re-attached to origin only inside the push steps, after cargo runs.
+          persist-credentials: false
 
       - name: Resolve version and baseline tag
         id: resolve
@@ -203,6 +208,11 @@ jobs:
           git add -A
           git commit -m "feat(data): bump PSL data to structured-public-domains v${VERSION}"
 
+          # Attach the token to origin now (checkout used persist-credentials:
+          # false), after the untrusted cargo steps have already run.
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
           # Push the TAG first: if a later step fails, the resync path (mode=sync)
           # recovers from "tag exists but not on main". The branch push uses
           # --force-with-lease so a rerun is idempotent even if a prior run left
@@ -225,6 +235,10 @@ jobs:
         run: |
           set -euo pipefail
           BRANCH="chore/psl-cascade-${VERSION}"
+
+          # Re-attach the token to origin (checkout used persist-credentials: false).
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           # Resync path: the release tag exists but never reached main (a prior
           # run failed after tagging). Recreate the branch at the released tag so

--- a/.github/workflows/psl-cascade.yml
+++ b/.github/workflows/psl-cascade.yml
@@ -201,11 +201,13 @@ jobs:
           git add -A
           git commit -m "feat(data): bump PSL data to structured-public-domains v${VERSION}"
 
-          # Push branch + tag, then create the release whose `created` event
-          # triggers crates.io publishing (release.yml).
-          git push -u origin "$BRANCH"
+          # Push the TAG first: if a later step fails, the resync path (mode=sync)
+          # recovers from "tag exists but not on main". The branch push uses
+          # --force-with-lease so a rerun is idempotent even if a prior run left
+          # the remote branch behind (avoids a permanent non-fast-forward block).
           git tag "v${NEW}"
           git push origin "v${NEW}"
+          git push --force-with-lease -u origin "$BRANCH"
           gh release create "v${NEW}" --title "v${NEW}" \
             --notes "PSL data update: structured-public-domains v${VERSION}"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,21 +442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psl"
-version = "2.1.213"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e78830163eebdf905adb55ba26ba9b3ba554b08bd84c2fbe3b643c8addf22c"
-dependencies = [
- "psl-types",
-]
-
-[[package]]
-name = "psl-types"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,14 +590,20 @@ version = "0.0.6"
 dependencies = [
  "criterion",
  "idna",
- "psl",
  "rayon",
  "roxmltree",
  "serde",
  "serde_json",
+ "structured-public-domains",
  "unicode-normalization",
  "unicode-security",
 ]
+
+[[package]]
+name = "structured-public-domains"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3af16a56d38889e7dbf293d98b51753fbdde61aa35d8a00b83112aeb22250a"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ categories = ["parser-implementations", "text-processing"]
 [features]
 default = ["serde", "psl"]
 serde = ["dep:serde"]
-psl = ["dep:psl"]
+psl = ["dep:structured-public-domains"]
 rayon = ["dep:rayon"]
 
 [dependencies]
 idna = "1.1"
-psl = { version = "2", optional = true }
+structured-public-domains = { version = "0.0.8", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 unicode-normalization = "0.1"
 unicode-security = "0.1"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Every Rust email crate stops at RFC validation. This one goes further:
 | Serde support | Yes | - | **Yes** |
 | Zero dependencies* | Yes | nom | `idna` + 3 |
 
-\* Dependencies: `idna`, `unicode-normalization`, `unicode-security`. Optional: `psl`, `serde`.
+\* Dependencies: `idna`, `unicode-normalization`, `unicode-security`. Optional: `structured-public-domains`, `serde`.
 
 ## Quick Start
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -94,12 +94,11 @@ fn validate_tld(domain: &str, pos: usize) -> Result<(), Error> {
 /// PSL-based domain validation (requires `psl` feature).
 #[cfg(feature = "psl")]
 fn validate_psl(domain: &str, pos: usize) -> Result<(), Error> {
-    match psl::suffix(domain.as_bytes()) {
-        Some(suffix) if suffix.is_known() => Ok(()),
-        _ => {
-            let tld = domain.rsplit('.').next().unwrap_or(domain);
-            Err(Error::new(ErrorKind::UnknownTld(tld.to_string()), pos))
-        }
+    if structured_public_domains::is_known_suffix(domain) {
+        Ok(())
+    } else {
+        let tld = domain.rsplit('.').next().unwrap_or(domain);
+        Err(Error::new(ErrorKind::UnknownTld(tld.to_string()), pos))
     }
 }
 

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -179,4 +179,26 @@ mod tests {
         let result = crate::EmailAddress::parse_with("user@[192.168.1.1]", &config);
         assert!(result.is_ok());
     }
+
+    // ── PSL validation (structured-public-domains backend) ──
+
+    #[cfg(feature = "psl")]
+    #[test]
+    fn psl_accepts_known_suffix() {
+        // A domain whose public suffix is in the PSL passes domain_check_psl.
+        let config = crate::Config::builder().domain_check_psl().build();
+        let result = crate::EmailAddress::parse_with("user@example.com", &config);
+        assert!(result.is_ok(), "known suffix must pass: {result:?}");
+    }
+
+    #[cfg(feature = "psl")]
+    #[test]
+    fn psl_rejects_unknown_suffix() {
+        // A made-up TLD matches only the PSL `*` default rule (is_known == false),
+        // so PSL validation rejects it with UnknownTld.
+        let config = crate::Config::builder().domain_check_psl().build();
+        let err = crate::EmailAddress::parse_with("user@example.invalidtldxyz", &config)
+            .expect_err("unknown suffix must be rejected");
+        assert!(matches!(err.kind(), crate::ErrorKind::UnknownTld(_)));
+    }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -197,10 +197,12 @@ mod tests {
         // A made-up TLD matches only the PSL `*` default rule (is_known == false),
         // so PSL validation rejects it with UnknownTld.
         let config = crate::Config::builder().domain_check_psl().build();
-        let err = match crate::EmailAddress::parse_with("user@example.invalidtldxyz", &config) {
-            Err(err) => err,
-            Ok(value) => panic!("unknown suffix must be rejected, got {value:?}"),
-        };
-        assert!(matches!(err.kind(), crate::ErrorKind::UnknownTld(_)));
+        // Single matches! over the Result keeps the test free of unwrap/expect
+        // and avoids an uncovered panic arm on the happy path.
+        let result = crate::EmailAddress::parse_with("user@example.invalidtldxyz", &config);
+        assert!(matches!(
+            result.as_ref().map_err(|e| e.kind()),
+            Err(crate::ErrorKind::UnknownTld(_))
+        ));
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -197,8 +197,10 @@ mod tests {
         // A made-up TLD matches only the PSL `*` default rule (is_known == false),
         // so PSL validation rejects it with UnknownTld.
         let config = crate::Config::builder().domain_check_psl().build();
-        let err = crate::EmailAddress::parse_with("user@example.invalidtldxyz", &config)
-            .expect_err("unknown suffix must be rejected");
+        let err = match crate::EmailAddress::parse_with("user@example.invalidtldxyz", &config) {
+            Err(err) => err,
+            Ok(value) => panic!("unknown suffix must be rejected, got {value:?}"),
+        };
         assert!(matches!(err.kind(), crate::ErrorKind::UnknownTld(_)));
     }
 }


### PR DESCRIPTION
## Summary

Two related changes that wire `structured-email-address` into the `structured-public-domains` data crate and its off-tag release cascade.

### 1. Swap PSL backend (`feat(deps)`)
- `psl` crate → `structured-public-domains` v0.0.8 behind the existing `psl` feature (~8x smaller embedded data, daily auto-updated, zero runtime deps).
- `validate_psl` now calls `is_known_suffix()` — semantically identical to the previous `psl::suffix(..).is_known()` (verified against the crate's `trie.rs`).
- Feature name kept as `psl` (no breaking rename — that stays in #7 proper, along with README feature-table/bench polish).

### 2. PSL cascade workflow (`ci`)
`.github/workflows/psl-cascade.yml` — receives `repository_dispatch: psl-updated` from structured-public-domains (or manual `workflow_dispatch`) and cuts a **data-only patch release off the last release tag**, mirroring that crate's own off-tag flow:
- token via `RELEASER_APP_*`, checkout `fetch-depth: 0`
- resolve target version + baseline tag, **no-op guard** (dep already at version) + **bootstrap guard** (tag predates the dependency → clear error)
- branch off the tag → bump dep + patch-bump own version → `cargo update --precise` + `cargo test --all-features` → `### Data` CHANGELOG entry → conventional commit → tag → `gh release create` (triggers `release.yml` → crates.io)
- sync onto main via a **merge commit** + `--auto` so release-plz stacks the pending code release on top

**Invariant:** the data release is cut from the last release tag, so it contains only the dependency bump — never unreleased code on main.

## Testing
- `cargo nextest run --all-features` → 111 pass
- `cargo nextest run --no-default-features` → 109 pass
- `cargo test --doc --all-features` → 5 pass
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `actionlint .github/workflows/psl-cascade.yml` → clean

## Preconditions before first cascade run (maintainer)
- [ ] SW Release Bot app installed on this repo (so `repository_dispatch` is delivered + token issues)
- [ ] "Allow merge commits" enabled in repo settings (for the merge-sync)
- [ ] Bootstrap: cascade only functions once the dependency swap is in a **tagged** release (post-merge code release). Until then the bootstrap guard correctly refuses. Run the manual test (`gh workflow run psl-cascade.yml -f version=0.0.8`) after that release.

Part of #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated “PSL Cascade” GitHub Actions workflow to create data-only patch releases and sync updates back to the main branch via an automatically merged PR.
* **Bug Fixes**
  * Improved PSL-based domain validation using structured public-suffix detection, returning `UnknownTld` for unrecognized suffixes.
  * Added feature-gated tests for valid and invalid PSL outcomes.
* **Documentation**
  * Updated the README to reference `structured-public-domains` instead of `psl`.
* **Refactor**
  * Updated feature wiring so the `psl` feature now enables `structured-public-domains`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->