### PR TITLE
feat(normalize): extensible provider registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Owned exclusively by the PSL data cascade (psl-cascade.yml), which cuts an
+      # off-tag data-only release. Dependabot bumping it on main would route a PSL
+      # data update through the code path — exactly what the cascade avoids.
+      - dependency-name: "structured-public-domains"
     commit-message:
       prefix: "chore(deps)"
   - package-ecosystem: "github-actions"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,41 @@ assert_eq!(email.tag(), Some("promo"));
 assert!(email.is_freemail());
 ```
 
+## Provider-Aware Normalization
+
+Each known provider carries its own rule (dot handling, case folding, subaddress
+separator, freemail flag). Enable `provider_aware()` to normalize a matched
+address by its provider's rule instead of the global policies, and register your
+own providers:
+
+```rust
+use structured_email_address::{Config, EmailAddress, ProviderRule};
+
+let config = Config::builder()
+    .provider_aware()            // matched provider's rule governs the address
+    .strip_subaddress()
+    .add_provider(               // extend the built-in registry
+        ProviderRule::new(["mail.corp.example"])
+            .strip_dots(true)
+            .lowercase_local(true)
+            .subaddress_separator(Some('-')),
+    )
+    .build();
+
+// Gmail's built-in rule strips dots + folds case even with no global policy set:
+let g = EmailAddress::parse_with("A.Li.Ce+promo@Gmail.com", &config)?;
+assert_eq!(g.canonical(), "alice@gmail.com");
+
+// Custom provider with a '-' separator:
+let c = EmailAddress::parse_with("John.Doe-tag@mail.corp.example", &config)?;
+assert_eq!(c.local_part(), "johndoe");
+assert_eq!(c.tag(), Some("tag"));
+```
+
+Built-in providers: Gmail/Googlemail (dot-stripping), Outlook, Yahoo, ProtonMail,
+iCloud, Yandex, Mail.ru, and other common freemail domains. `is_freemail()`
+consults the same registry regardless of `provider_aware`.
+
 ## Display Names
 
 ```rust

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@
 //! The builder pattern allows fine-grained control over every aspect of
 //! email handling — from RFC strictness level to provider-aware normalization.
 
+use crate::provider::{ProviderRegistry, ProviderRule};
+
 /// How strictly to validate RFC grammar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Strictness {
@@ -95,6 +97,12 @@ pub struct Config {
     pub(crate) allow_domain_literal: bool,
     pub(crate) allow_display_name: bool,
     pub(crate) require_tld_dot: bool,
+    /// When true, a matched provider rule's dot/case/separator override the
+    /// global policies for that address.
+    pub(crate) provider_aware: bool,
+    /// Provider registry: source of truth for [`is_freemail`](crate::EmailAddress::is_freemail)
+    /// (always) and provider-aware normalization (when `provider_aware`).
+    pub(crate) providers: ProviderRegistry,
 }
 
 impl Default for Config {
@@ -110,6 +118,8 @@ impl Default for Config {
             allow_domain_literal: false,
             allow_display_name: false,
             require_tld_dot: true,
+            provider_aware: false,
+            providers: ProviderRegistry::builtin(),
         }
     }
 }
@@ -224,6 +234,37 @@ impl ConfigBuilder {
     /// Syntax-only domain check (default). Resets from `Psl`/`Tld` back to syntax.
     pub fn domain_check_syntax(mut self) -> Self {
         self.0.domain_check = DomainCheck::Syntax;
+        self
+    }
+
+    /// Enable provider-aware normalization.
+    ///
+    /// When enabled, an address whose domain matches a registered
+    /// [`ProviderRule`] is normalized by that provider's rule (dot stripping,
+    /// case folding, subaddress separator) instead of the global policies.
+    /// Addresses with no matching provider still use the global policies.
+    ///
+    /// Provider lookups for [`is_freemail`](crate::EmailAddress::is_freemail)
+    /// work regardless of this setting — it only gates normalization.
+    pub fn provider_aware(mut self) -> Self {
+        self.0.provider_aware = true;
+        self
+    }
+
+    /// Register a custom [`ProviderRule`], extending the built-in registry.
+    ///
+    /// User rules take precedence over built-ins for the same domain, so this
+    /// can also redefine a built-in provider. Affects [`is_freemail`](crate::EmailAddress::is_freemail)
+    /// always, and normalization when [`provider_aware`](Self::provider_aware) is set.
+    pub fn add_provider(mut self, rule: ProviderRule) -> Self {
+        self.0.providers.add(rule);
+        self
+    }
+
+    /// Replace the entire provider registry (e.g. start from
+    /// [`ProviderRegistry::empty`](crate::ProviderRegistry::empty)).
+    pub fn providers(mut self, registry: ProviderRegistry) -> Self {
+        self.0.providers = registry;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ mod config;
 mod error;
 mod normalize;
 mod parser;
+mod provider;
 mod validate;
 
 pub use config::{
@@ -49,6 +50,7 @@ pub use config::{
 };
 pub use error::{Error, ErrorKind};
 pub use normalize::confusable_skeleton;
+pub use provider::{ProviderRegistry, ProviderRule};
 
 /// A parsed, validated, and normalized email address.
 ///
@@ -69,6 +71,8 @@ pub struct EmailAddress {
     display_name: Option<String>,
     /// Confusable skeleton, if config enabled it.
     skeleton: Option<String>,
+    /// Whether the domain is a known freemail provider (from the registry).
+    freemail: bool,
 }
 
 impl EmailAddress {
@@ -84,6 +88,13 @@ impl EmailAddress {
         let normalized = normalize::normalize(&parsed, config)?;
         validate::validate(&parsed, &normalized, config)?;
 
+        // Freemail status comes from the provider registry (built-ins + any
+        // custom rules), independent of provider-aware normalization.
+        let freemail = config
+            .providers
+            .lookup(&normalized.domain)
+            .is_some_and(|p| p.is_freemail());
+
         Ok(Self {
             original: parsed.input.to_string(),
             local_part: normalized.local_part,
@@ -92,6 +103,7 @@ impl EmailAddress {
             domain_unicode: normalized.domain_unicode,
             display_name: normalized.display_name,
             skeleton: normalized.skeleton,
+            freemail,
         })
     }
 
@@ -179,9 +191,13 @@ impl EmailAddress {
         self.skeleton.as_deref()
     }
 
-    /// Check if the domain is a well-known freemail provider.
+    /// Check if the domain is a known freemail provider.
+    ///
+    /// Determined from the [`ProviderRegistry`] in the [`Config`] used to parse
+    /// (built-in providers plus any registered via
+    /// [`ConfigBuilder::add_provider`]).
     pub fn is_freemail(&self) -> bool {
-        is_freemail_domain(&self.domain)
+        self.freemail
     }
 
     /// Parse a batch of email addresses with the given configuration.
@@ -379,39 +395,6 @@ impl<'de> serde::Deserialize<'de> for EmailAddress {
     }
 }
 
-/// Check if a domain is a well-known freemail provider.
-fn is_freemail_domain(domain: &str) -> bool {
-    matches!(
-        domain,
-        "gmail.com"
-            | "googlemail.com"
-            | "yahoo.com"
-            | "yahoo.co.uk"
-            | "yahoo.co.jp"
-            | "outlook.com"
-            | "hotmail.com"
-            | "live.com"
-            | "msn.com"
-            | "aol.com"
-            | "protonmail.com"
-            | "proton.me"
-            | "icloud.com"
-            | "me.com"
-            | "mac.com"
-            | "mail.com"
-            | "zoho.com"
-            | "yandex.ru"
-            | "yandex.com"
-            | "mail.ru"
-            | "gmx.com"
-            | "gmx.de"
-            | "web.de"
-            | "tutanota.com"
-            | "tuta.io"
-            | "fastmail.com"
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -470,6 +453,85 @@ mod tests {
 
         let email: EmailAddress = "user@company.com".parse().unwrap_or_else(|e| panic!("{e}"));
         assert!(!email.is_freemail());
+    }
+
+    #[test]
+    fn freemail_via_custom_provider() {
+        // A registered custom provider marked freemail is reported by is_freemail().
+        use crate::ProviderRule;
+        let config = Config::builder()
+            .add_provider(ProviderRule::new(["freebie.example"]).freemail(true))
+            .build();
+        let email = EmailAddress::parse_with("user@freebie.example", &config)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(email.is_freemail());
+    }
+
+    // ── Provider-aware normalization (#5) ──
+
+    #[test]
+    fn provider_aware_gmail_normalizes_by_rule() {
+        // provider_aware applies Gmail's rule (strip dots, fold case, '+' tag)
+        // without setting any global dot/case policy. strip_subaddress drops the
+        // extracted tag from the canonical form.
+        let config = Config::builder()
+            .provider_aware()
+            .strip_subaddress()
+            .build();
+        let email = EmailAddress::parse_with("A.Li.Ce+promo@Gmail.com", &config)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "alice");
+        assert_eq!(email.tag(), Some("promo"));
+        assert_eq!(email.domain(), "gmail.com");
+    }
+
+    #[test]
+    fn provider_aware_gmail_preserves_tag_by_default() {
+        // Default subaddress policy keeps the tag in the canonical local part;
+        // dots are still stripped and case folded by the Gmail rule.
+        let config = Config::builder().provider_aware().build();
+        let email = EmailAddress::parse_with("A.Li.Ce+promo@Gmail.com", &config)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "alice+promo");
+        assert_eq!(email.tag(), Some("promo"));
+    }
+
+    #[test]
+    fn provider_aware_leaves_non_provider_domains_to_global_policy() {
+        // A non-provider domain is untouched by provider rules: dots preserved,
+        // local-part case preserved (global defaults).
+        let config = Config::builder().provider_aware().build();
+        let email = EmailAddress::parse_with("A.L.I.C.E@example.com", &config)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "A.L.I.C.E");
+        assert_eq!(email.domain(), "example.com");
+    }
+
+    #[test]
+    fn provider_aware_off_does_not_strip_gmail_dots() {
+        // Without provider_aware and without dots_gmail_only, gmail dots stay.
+        let email: EmailAddress = "a.b.c@gmail.com".parse().unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "a.b.c");
+    }
+
+    #[test]
+    fn custom_provider_aware_rule_applies() {
+        use crate::ProviderRule;
+        // Custom provider: strips dots, '-' separator.
+        let config = Config::builder()
+            .provider_aware()
+            .strip_subaddress()
+            .add_provider(
+                ProviderRule::new(["corp.example"])
+                    .strip_dots(true)
+                    .lowercase_local(true)
+                    .subaddress_separator(Some('-')),
+            )
+            .build();
+        let email = EmailAddress::parse_with("John.Doe-tag@corp.example", &config)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "johndoe");
+        assert_eq!(email.tag(), Some("tag"));
     }
 
     // ── Configured parsing ──

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,8 +518,9 @@ mod tests {
         assert_eq!(email.local_part(), "A.B");
 
         // A global lowercase policy is not provider-specific, so it still folds
-        // a quoted local-part.
-        let config = Config::builder().lowercase_all().build();
+        // a quoted local-part — even when a provider rule matches (the rule's
+        // own folding is skipped for quoted, but the global policy still applies).
+        let config = Config::builder().provider_aware().lowercase_all().build();
         let email = EmailAddress::parse_with("\"A.B\"@gmail.com", &config)
             .unwrap_or_else(|e| panic!("{e}"));
         assert_eq!(email.local_part(), "a.b");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,6 +508,24 @@ mod tests {
     }
 
     #[test]
+    fn provider_aware_quoted_local_preserves_case() {
+        // A quoted local-part is literal: the provider rule's case folding
+        // (Gmail) must NOT apply inside it, just as dots and the subaddress
+        // separator don't. Without a global lowercase policy, case is preserved.
+        let config = Config::builder().provider_aware().build();
+        let email = EmailAddress::parse_with("\"A.B\"@gmail.com", &config)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "A.B");
+
+        // A global lowercase policy is not provider-specific, so it still folds
+        // a quoted local-part.
+        let config = Config::builder().lowercase_all().build();
+        let email = EmailAddress::parse_with("\"A.B\"@gmail.com", &config)
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "a.b");
+    }
+
+    #[test]
     fn provider_aware_off_does_not_strip_gmail_dots() {
         // Without provider_aware and without dots_gmail_only, gmail dots stay.
         let email: EmailAddress = "a.b.c@gmail.com".parse().unwrap_or_else(|e| panic!("{e}"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,6 +534,32 @@ mod tests {
         assert_eq!(email.tag(), Some("tag"));
     }
 
+    #[test]
+    fn idn_provider_rule_consistent_across_normalization_and_freemail() {
+        use crate::ProviderRule;
+        // A provider rule registered with the Unicode domain must apply to the
+        // IDNA-encoded address for BOTH provider-aware normalization and
+        // is_freemail() — the canonical domain is used at both call sites.
+        let config = Config::builder()
+            .provider_aware()
+            .add_provider(
+                ProviderRule::new(["münchen.de"])
+                    .strip_dots(true)
+                    .lowercase_local(true)
+                    .freemail(true),
+            )
+            .build();
+        let email =
+            EmailAddress::parse_with("A.B@münchen.de", &config).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.domain(), "xn--mnchen-3ya.de");
+        assert_eq!(
+            email.local_part(),
+            "ab",
+            "provider rule strips dots + folds case"
+        );
+        assert!(email.is_freemail(), "same rule drives is_freemail");
+    }
+
     // ── Configured parsing ──
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -560,6 +560,29 @@ mod tests {
         assert!(email.is_freemail(), "same rule drives is_freemail");
     }
 
+    #[test]
+    fn dots_gmail_only_ignores_custom_providers() {
+        use crate::ProviderRule;
+        // GmailOnly is a legacy mode tied to the built-in dot-stripping providers
+        // (Gmail/Googlemail). Custom providers affect normalization ONLY under
+        // provider_aware(); a custom strip_dots rule must NOT leak into GmailOnly
+        // when provider_aware is off.
+        let config = Config::builder()
+            .dots_gmail_only()
+            .add_provider(ProviderRule::new(["corp.example"]).strip_dots(true))
+            .build();
+
+        // The custom provider's strip_dots is ignored: dots are preserved.
+        let email =
+            EmailAddress::parse_with("a.b@corp.example", &config).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "a.b");
+
+        // Built-in Gmail still strips dots under GmailOnly.
+        let email =
+            EmailAddress::parse_with("a.b.c@gmail.com", &config).unwrap_or_else(|e| panic!("{e}"));
+        assert_eq!(email.local_part(), "abc");
+    }
+
     // ── Configured parsing ──
 
     #[test]

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -71,9 +71,11 @@ pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normaliz
     };
 
     // Step 2: Case folding (provider rule overrides the global case policy).
+    // A quoted local-part is literal, so provider semantics never apply inside
+    // it (same as dots/subaddress below) — only a global lowercase policy does.
     let lowercase_local = match provider {
-        Some(p) => p.folds_case(),
-        None => matches!(config.case_policy, CasePolicy::All),
+        Some(p) if !is_quoted => p.folds_case(),
+        _ => matches!(config.case_policy, CasePolicy::All),
     };
     let cased_local = if lowercase_local {
         nfc_local.to_lowercase()

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -45,11 +45,27 @@ pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normaliz
     let nfc_local: String = unquoted_local.nfc().collect();
     let nfc_domain: String = domain_str.nfc().collect();
 
+    // Canonical (IDNA-ASCII) domain — computed up front so provider lookup,
+    // freemail detection (in parse_with), and the final domain all use the SAME
+    // form. Domain literals ([192.168.1.1]) are IPs, not hostnames — skip IDNA.
+    // Strict mode: STD3 ASCII deny-list, hyphen checks, DNS length verification.
+    let canonical_domain = if nfc_domain.starts_with('[') {
+        nfc_domain.to_lowercase()
+    } else {
+        idna::domain_to_ascii_strict(&nfc_domain).map_err(|e| {
+            Error::new(
+                ErrorKind::IdnaError(format!("{}: {}", nfc_domain, e)),
+                parsed.domain.start,
+            )
+        })?
+    };
+
     // Provider-aware overrides: when enabled and the domain matches a registered
     // provider, that rule's case / separator / dot policy governs this address
     // instead of the global policies. Non-matching domains use the global policies.
+    // Lookup uses the canonical domain so IDN rules match consistently.
     let provider = if config.provider_aware {
-        config.providers.lookup(&nfc_domain)
+        config.providers.lookup(&canonical_domain)
     } else {
         None
     };
@@ -102,7 +118,7 @@ pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normaliz
                 // Strip only for a registered provider that ignores dots.
                 DotPolicy::GmailOnly => config
                     .providers
-                    .lookup(&nfc_domain)
+                    .lookup(&canonical_domain)
                     .is_some_and(|p| p.strips_dots()),
             },
         };
@@ -114,21 +130,7 @@ pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normaliz
         (base, tag, after_dots)
     };
 
-    // Step 6: Domain — IDNA encoding (punycode for international domains).
-    // Domain literals (e.g., [192.168.1.1]) are IP addresses, not hostnames — skip IDNA.
-    // Use strict mode: STD3 ASCII deny-list, hyphen checks, DNS length verification.
-    let canonical_domain = if nfc_domain.starts_with('[') {
-        nfc_domain.to_lowercase()
-    } else {
-        idna::domain_to_ascii_strict(&nfc_domain).map_err(|e| {
-            Error::new(
-                ErrorKind::IdnaError(format!("{}: {}", nfc_domain, e)),
-                parsed.domain.start,
-            )
-        })?
-    };
-
-    // Step 7: IDNA roundtrip — recover Unicode domain when punycode is present.
+    // Step 6: IDNA roundtrip — recover Unicode domain when punycode is present.
     let domain_unicode = if canonical_domain
         .split('.')
         .any(|label| label.starts_with("xn--"))

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -115,9 +115,11 @@ pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normaliz
             None => match config.dot_policy {
                 DotPolicy::Preserve => false,
                 DotPolicy::Always => true,
-                // Strip only for a registered provider that ignores dots.
-                DotPolicy::GmailOnly => config
-                    .providers
+                // Strip only for a BUILT-IN provider that ignores dots
+                // (Gmail/Googlemail). Custom providers affect normalization only
+                // under provider_aware(), so the legacy GmailOnly mode consults
+                // the built-in registry, never config.providers.
+                DotPolicy::GmailOnly => crate::provider::builtin_ref()
                     .lookup(&canonical_domain)
                     .is_some_and(|p| p.strips_dots()),
             },

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -45,10 +45,24 @@ pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normaliz
     let nfc_local: String = unquoted_local.nfc().collect();
     let nfc_domain: String = domain_str.nfc().collect();
 
-    // Step 2: Case folding.
-    let cased_local = match config.case_policy {
-        CasePolicy::All => nfc_local.to_lowercase(),
-        CasePolicy::Domain | CasePolicy::Preserve => nfc_local,
+    // Provider-aware overrides: when enabled and the domain matches a registered
+    // provider, that rule's case / separator / dot policy governs this address
+    // instead of the global policies. Non-matching domains use the global policies.
+    let provider = if config.provider_aware {
+        config.providers.lookup(&nfc_domain)
+    } else {
+        None
+    };
+
+    // Step 2: Case folding (provider rule overrides the global case policy).
+    let lowercase_local = match provider {
+        Some(p) => p.folds_case(),
+        None => matches!(config.case_policy, CasePolicy::All),
+    };
+    let cased_local = if lowercase_local {
+        nfc_local.to_lowercase()
+    } else {
+        nfc_local
     };
 
     // Steps 3-5: Subaddress and dot normalization apply only to unquoted local-parts.
@@ -56,24 +70,47 @@ pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normaliz
     let (_base_local, tag, local_after_dots) = if is_quoted {
         (cased_local.clone(), None, cased_local)
     } else {
-        // Step 3: Extract subaddress tag.
-        let sep = config.subaddress_separator;
-        let (base, tag) = match cased_local.split_once(sep) {
-            Some((base, tag)) if !base.is_empty() => (base.to_string(), Some(tag.to_string())),
-            _ => (cased_local, None),
+        // Step 3: Extract subaddress tag. A provider with no subaddressing
+        // (separator None) disables tag extraction.
+        let sep: Option<char> = match provider {
+            Some(p) => p.separator(),
+            None => Some(config.subaddress_separator),
+        };
+        let (base, tag) = match sep {
+            Some(s) => match cased_local.split_once(s) {
+                Some((base, tag)) if !base.is_empty() => (base.to_string(), Some(tag.to_string())),
+                _ => (cased_local, None),
+            },
+            None => (cased_local, None),
         };
 
         // Step 4: Apply subaddress policy to canonical form.
         let local_after_tag = match config.subaddress {
             SubaddressPolicy::Strip => base.clone(),
-            SubaddressPolicy::Preserve => match &tag {
-                Some(t) => format!("{}{}{}", base, sep, t),
-                None => base.clone(),
+            SubaddressPolicy::Preserve => match (&tag, sep) {
+                (Some(t), Some(s)) => format!("{base}{s}{t}"),
+                _ => base.clone(),
             },
         };
 
-        // Step 5: Dot policy.
-        let after_dots = apply_dot_policy(&local_after_tag, &nfc_domain, config.dot_policy);
+        // Step 5: Dot stripping (provider rule overrides the global dot policy).
+        let strip = match provider {
+            Some(p) => p.strips_dots(),
+            None => match config.dot_policy {
+                DotPolicy::Preserve => false,
+                DotPolicy::Always => true,
+                // Strip only for a registered provider that ignores dots.
+                DotPolicy::GmailOnly => config
+                    .providers
+                    .lookup(&nfc_domain)
+                    .is_some_and(|p| p.strips_dots()),
+            },
+        };
+        let after_dots = if strip {
+            local_after_tag.replace('.', "")
+        } else {
+            local_after_tag
+        };
         (base, tag, after_dots)
     };
 
@@ -127,26 +164,6 @@ pub(crate) fn normalize(parsed: &Parsed<'_>, config: &Config) -> Result<Normaliz
         display_name,
         skeleton: skel,
     })
-}
-
-/// Apply dot-stripping policy.
-fn apply_dot_policy(local: &str, domain: &str, policy: DotPolicy) -> String {
-    match policy {
-        DotPolicy::Preserve => local.to_string(),
-        DotPolicy::Always => local.replace('.', ""),
-        DotPolicy::GmailOnly => {
-            if is_gmail_domain(domain) {
-                local.replace('.', "")
-            } else {
-                local.to_string()
-            }
-        }
-    }
-}
-
-/// Check if domain is a Gmail domain (case-insensitive, allocation-free).
-fn is_gmail_domain(domain: &str) -> bool {
-    domain.eq_ignore_ascii_case("gmail.com") || domain.eq_ignore_ascii_case("googlemail.com")
 }
 
 /// Remove RFC 5322 quoted-pair backslashes (`\"` → `"`, `\\` → `\`)

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -137,6 +137,45 @@ pub struct ProviderRegistry {
     rules: Vec<ProviderRule>,
 }
 
+// Process-wide built-in registry, constructed once. `builtin()` clones it and
+// the GmailOnly dot-policy borrows it, so neither pays a per-call allocation.
+// no-std: once_cell::race::OnceBox (alloc) or a caller-injected registry.
+static BUILTIN: std::sync::LazyLock<ProviderRegistry> = std::sync::LazyLock::new(|| {
+    let p = |domains: &[&str]| {
+        ProviderRule::new(domains.iter().copied())
+            .lowercase_local(true)
+            .freemail(true)
+    };
+    ProviderRegistry {
+        rules: vec![
+            p(&["gmail.com", "googlemail.com"]).strip_dots(true),
+            p(&["outlook.com", "hotmail.com", "live.com", "msn.com"]),
+            p(&["yahoo.com", "yahoo.co.uk", "yahoo.co.jp"]),
+            p(&["protonmail.com", "proton.me"]),
+            p(&["icloud.com", "me.com", "mac.com"]),
+            p(&["yandex.ru", "yandex.com"]),
+            p(&["mail.ru"]),
+            // Freemail providers without special normalization quirks.
+            p(&[
+                "aol.com",
+                "mail.com",
+                "zoho.com",
+                "gmx.com",
+                "gmx.de",
+                "web.de",
+                "tutanota.com",
+                "tuta.io",
+                "fastmail.com",
+            ]),
+        ],
+    }
+});
+
+/// Borrow the process-wide built-in registry without allocating.
+pub(crate) fn builtin_ref() -> &'static ProviderRegistry {
+    &BUILTIN
+}
+
 impl ProviderRegistry {
     /// An empty registry.
     pub fn empty() -> Self {
@@ -147,35 +186,11 @@ impl ProviderRegistry {
     ///
     /// Only Gmail/Googlemail ignore dots; every entry folds local-part case and
     /// uses `+` as its subaddress separator. All built-ins are freemail.
+    ///
+    /// Returns an owned clone of a process-wide shared registry, so the rule set
+    /// is constructed (and its domains IDNA-canonicalized) only once.
     pub fn builtin() -> Self {
-        let p = |domains: &[&str]| {
-            ProviderRule::new(domains.iter().copied())
-                .lowercase_local(true)
-                .freemail(true)
-        };
-        Self {
-            rules: vec![
-                p(&["gmail.com", "googlemail.com"]).strip_dots(true),
-                p(&["outlook.com", "hotmail.com", "live.com", "msn.com"]),
-                p(&["yahoo.com", "yahoo.co.uk", "yahoo.co.jp"]),
-                p(&["protonmail.com", "proton.me"]),
-                p(&["icloud.com", "me.com", "mac.com"]),
-                p(&["yandex.ru", "yandex.com"]),
-                p(&["mail.ru"]),
-                // Freemail providers without special normalization quirks.
-                p(&[
-                    "aol.com",
-                    "mail.com",
-                    "zoho.com",
-                    "gmx.com",
-                    "gmx.de",
-                    "web.de",
-                    "tutanota.com",
-                    "tuta.io",
-                    "fastmail.com",
-                ]),
-            ],
-        }
+        builtin_ref().clone()
     }
 
     /// Add a rule. User-added rules take precedence over earlier ones.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -38,10 +38,15 @@ pub struct ProviderRule {
 }
 
 impl ProviderRule {
-    /// Create a rule for the given domains (matched case-insensitively).
+    /// Create a rule for the given domains.
+    ///
+    /// Domains are stored in their IDNA-ASCII (punycode) canonical form so a
+    /// rule registered as `münchen.de` and one as `xn--mnchen-3ya.de` are
+    /// equivalent, and matching agrees with the canonical domain used elsewhere.
     ///
     /// Defaults: no dot stripping, no case folding, `+` subaddress separator,
-    /// and `is_freemail = true` (most registered providers are freemail).
+    /// and `is_freemail = false` (a custom rule is treated as a private domain
+    /// unless you opt in with [`freemail(true)`](Self::freemail)).
     pub fn new<I, S>(domains: I) -> Self
     where
         I: IntoIterator<Item = S>,
@@ -50,12 +55,12 @@ impl ProviderRule {
         Self {
             domains: domains
                 .into_iter()
-                .map(|d| d.into().to_ascii_lowercase().into_boxed_str())
+                .map(|d| canonical_domain(&d.into()))
                 .collect(),
             strip_dots: false,
             lowercase_local: false,
             subaddress_sep: Some('+'),
-            is_freemail: true,
+            is_freemail: false,
         }
     }
 
@@ -88,9 +93,17 @@ impl ProviderRule {
         self
     }
 
-    /// Returns true if `domain` (compared case-insensitively) belongs to this provider.
+    /// Returns true if `domain` belongs to this provider.
+    ///
+    /// The domain is canonicalized to IDNA-ASCII before comparison, so Unicode
+    /// and punycode spellings of the same domain match.
     pub fn matches(&self, domain: &str) -> bool {
-        self.domains.iter().any(|d| domain.eq_ignore_ascii_case(d))
+        self.matches_canonical(&canonical_domain(domain))
+    }
+
+    /// Match against a domain already in canonical (IDNA-ASCII) form.
+    fn matches_canonical(&self, canonical: &str) -> bool {
+        self.domains.iter().any(|d| &**d == canonical)
     }
 
     /// Whether the local part's dots are insignificant.
@@ -135,7 +148,11 @@ impl ProviderRegistry {
     /// Only Gmail/Googlemail ignore dots; every entry folds local-part case and
     /// uses `+` as its subaddress separator. All built-ins are freemail.
     pub fn builtin() -> Self {
-        let p = |domains: &[&str]| ProviderRule::new(domains.iter().copied()).lowercase_local(true);
+        let p = |domains: &[&str]| {
+            ProviderRule::new(domains.iter().copied())
+                .lowercase_local(true)
+                .freemail(true)
+        };
         Self {
             rules: vec![
                 p(&["gmail.com", "googlemail.com"]).strip_dots(true),
@@ -176,9 +193,14 @@ impl ProviderRegistry {
     /// Look up the rule for a domain, or `None` if no provider matches.
     ///
     /// Most-recently-added rules win, so a custom rule overrides a built-in for
-    /// the same domain.
+    /// the same domain. The domain is canonicalized to IDNA-ASCII once, so
+    /// Unicode and punycode spellings resolve to the same rule.
     pub fn lookup(&self, domain: &str) -> Option<&ProviderRule> {
-        self.rules.iter().rev().find(|r| r.matches(domain))
+        let canonical = canonical_domain(domain);
+        self.rules
+            .iter()
+            .rev()
+            .find(|r| r.matches_canonical(&canonical))
     }
 }
 
@@ -186,6 +208,16 @@ impl Default for ProviderRegistry {
     fn default() -> Self {
         Self::builtin()
     }
+}
+
+/// Canonicalize a domain to its IDNA-ASCII (punycode) form, lowercased.
+///
+/// Falls back to ASCII lowercasing if the input is not a valid domain, so
+/// matching never panics on arbitrary registry input.
+fn canonical_domain(domain: &str) -> Box<str> {
+    idna::domain_to_ascii(domain)
+        .unwrap_or_else(|_| domain.to_ascii_lowercase())
+        .into_boxed_str()
 }
 
 #[cfg(test)]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,0 +1,192 @@
+//! Provider-aware normalization rules.
+//!
+//! Different mail providers treat the local part differently: Gmail ignores
+//! dots, most freemail providers fold case, subaddress separators vary. A
+//! [`ProviderRegistry`] maps domains to [`ProviderRule`]s so normalization can
+//! be provider-aware, and applications can register their own providers.
+//!
+//! The registry is also the source of truth for [`EmailAddress::is_freemail`],
+//! independent of whether provider-aware normalization is enabled.
+//!
+//! [`EmailAddress::is_freemail`]: crate::EmailAddress::is_freemail
+
+/// Normalization rule for one mail provider (a set of equivalent domains).
+///
+/// Construct with [`ProviderRule::new`] and refine with the builder-style
+/// setters. Fields are private so the rule can gain options without a breaking
+/// change.
+///
+/// # Example
+///
+/// ```
+/// use structured_email_address::ProviderRule;
+///
+/// // A corporate provider that ignores dots and folds case, tag separator '+'.
+/// let rule = ProviderRule::new(["mail.example.com"])
+///     .strip_dots(true)
+///     .lowercase_local(true)
+///     .freemail(false);
+/// assert!(rule.matches("MAIL.EXAMPLE.COM"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct ProviderRule {
+    domains: Vec<Box<str>>,
+    strip_dots: bool,
+    lowercase_local: bool,
+    subaddress_sep: Option<char>,
+    is_freemail: bool,
+}
+
+impl ProviderRule {
+    /// Create a rule for the given domains (matched case-insensitively).
+    ///
+    /// Defaults: no dot stripping, no case folding, `+` subaddress separator,
+    /// and `is_freemail = true` (most registered providers are freemail).
+    pub fn new<I, S>(domains: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            domains: domains
+                .into_iter()
+                .map(|d| d.into().to_ascii_lowercase().into_boxed_str())
+                .collect(),
+            strip_dots: false,
+            lowercase_local: false,
+            subaddress_sep: Some('+'),
+            is_freemail: true,
+        }
+    }
+
+    /// Set whether dots in the local part are insignificant (e.g. Gmail).
+    #[must_use]
+    pub fn strip_dots(mut self, yes: bool) -> Self {
+        self.strip_dots = yes;
+        self
+    }
+
+    /// Set whether the local part is case-insensitive (folded to lowercase).
+    #[must_use]
+    pub fn lowercase_local(mut self, yes: bool) -> Self {
+        self.lowercase_local = yes;
+        self
+    }
+
+    /// Set the subaddress separator, or `None` if the provider has no
+    /// subaddressing.
+    #[must_use]
+    pub fn subaddress_separator(mut self, sep: Option<char>) -> Self {
+        self.subaddress_sep = sep;
+        self
+    }
+
+    /// Set whether this provider is a free webmail provider.
+    #[must_use]
+    pub fn freemail(mut self, yes: bool) -> Self {
+        self.is_freemail = yes;
+        self
+    }
+
+    /// Returns true if `domain` (compared case-insensitively) belongs to this provider.
+    pub fn matches(&self, domain: &str) -> bool {
+        self.domains.iter().any(|d| domain.eq_ignore_ascii_case(d))
+    }
+
+    /// Whether the local part's dots are insignificant.
+    pub fn strips_dots(&self) -> bool {
+        self.strip_dots
+    }
+
+    /// Whether the local part is case-insensitive.
+    pub fn folds_case(&self) -> bool {
+        self.lowercase_local
+    }
+
+    /// The provider's subaddress separator, if any.
+    pub fn separator(&self) -> Option<char> {
+        self.subaddress_sep
+    }
+
+    /// Whether this is a free webmail provider.
+    pub fn is_freemail(&self) -> bool {
+        self.is_freemail
+    }
+}
+
+/// A set of [`ProviderRule`]s with domain lookup.
+///
+/// [`builtin`](Self::builtin) seeds the well-known providers; applications can
+/// extend it with [`add`](Self::add). User-added rules take precedence over
+/// built-ins, so a custom rule can redefine a built-in provider.
+#[derive(Debug, Clone)]
+pub struct ProviderRegistry {
+    rules: Vec<ProviderRule>,
+}
+
+impl ProviderRegistry {
+    /// An empty registry.
+    pub fn empty() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    /// The built-in registry of well-known mail providers.
+    ///
+    /// Only Gmail/Googlemail ignore dots; every entry folds local-part case and
+    /// uses `+` as its subaddress separator. All built-ins are freemail.
+    pub fn builtin() -> Self {
+        let p = |domains: &[&str]| ProviderRule::new(domains.iter().copied()).lowercase_local(true);
+        Self {
+            rules: vec![
+                p(&["gmail.com", "googlemail.com"]).strip_dots(true),
+                p(&["outlook.com", "hotmail.com", "live.com", "msn.com"]),
+                p(&["yahoo.com", "yahoo.co.uk", "yahoo.co.jp"]),
+                p(&["protonmail.com", "proton.me"]),
+                p(&["icloud.com", "me.com", "mac.com"]),
+                p(&["yandex.ru", "yandex.com"]),
+                p(&["mail.ru"]),
+                // Freemail providers without special normalization quirks.
+                p(&[
+                    "aol.com",
+                    "mail.com",
+                    "zoho.com",
+                    "gmx.com",
+                    "gmx.de",
+                    "web.de",
+                    "tutanota.com",
+                    "tuta.io",
+                    "fastmail.com",
+                ]),
+            ],
+        }
+    }
+
+    /// Add a rule. User-added rules take precedence over earlier ones.
+    pub fn add(&mut self, rule: ProviderRule) {
+        self.rules.push(rule);
+    }
+
+    /// Builder-style [`add`](Self::add).
+    #[must_use]
+    pub fn with(mut self, rule: ProviderRule) -> Self {
+        self.add(rule);
+        self
+    }
+
+    /// Look up the rule for a domain, or `None` if no provider matches.
+    ///
+    /// Most-recently-added rules win, so a custom rule overrides a built-in for
+    /// the same domain.
+    pub fn lookup(&self, domain: &str) -> Option<&ProviderRule> {
+        self.rules.iter().rev().find(|r| r.matches(domain))
+    }
+}
+
+impl Default for ProviderRegistry {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/provider/tests.rs
+++ b/src/provider/tests.rs
@@ -134,6 +134,33 @@ fn idn_rule_matches_unicode_and_punycode() {
 }
 
 #[test]
+fn idn_rule_matches_decomposed_unicode_nfc() {
+    // IDNA canonicalization applies Unicode NFC, so a rule registered with the
+    // composed form (ü = U+00FC) still matches a lookup using the decomposed
+    // form (u + combining diaeresis U+0308) — the two are the same domain.
+    let reg =
+        ProviderRegistry::empty().with(ProviderRule::new(["m\u{00fc}nchen.de"]).freemail(true));
+    assert!(
+        reg.lookup("mu\u{0308}nchen.de").is_some(),
+        "decomposed spelling matches the composed rule via NFC"
+    );
+}
+
+#[test]
+fn idn_rule_rejects_confusable_lookalike() {
+    // A visually confusable domain using Cyrillic 'а' (U+0430) instead of Latin
+    // 'a' (U+0061) is a DIFFERENT domain: it canonicalizes to a different label
+    // and must not match the Latin rule (no homoglyph collision in lookup).
+    let reg = ProviderRegistry::empty().with(ProviderRule::new(["gmail.com"]).freemail(true));
+    assert!(
+        reg.lookup("gm\u{0430}il.com").is_none(),
+        "Cyrillic lookalike must not match the Latin gmail.com rule"
+    );
+    // Sanity: the genuine Latin domain still matches.
+    assert!(reg.lookup("gmail.com").is_some());
+}
+
+#[test]
 fn rule_no_subaddressing() {
     let r = ProviderRule::new(["x.example"]).subaddress_separator(None);
     assert_eq!(r.separator(), None);

--- a/src/provider/tests.rs
+++ b/src/provider/tests.rs
@@ -1,15 +1,23 @@
 use super::*;
 
+/// Helper: look up a rule, panicking with a clear message if absent (no unwrap/expect).
+fn rule<'a>(reg: &'a ProviderRegistry, domain: &str) -> &'a ProviderRule {
+    match reg.lookup(domain) {
+        Some(r) => r,
+        None => panic!("expected a provider rule for {domain}"),
+    }
+}
+
 #[test]
 fn builtin_gmail_rule() {
     let reg = ProviderRegistry::builtin();
-    let g = reg.lookup("gmail.com").expect("gmail is a known provider");
+    let g = rule(&reg, "gmail.com");
     assert!(g.strips_dots(), "gmail ignores dots");
     assert!(g.folds_case());
     assert_eq!(g.separator(), Some('+'));
     assert!(g.is_freemail());
     // Alias resolves to the same rule.
-    assert!(reg.lookup("googlemail.com").unwrap().strips_dots());
+    assert!(rule(&reg, "googlemail.com").strips_dots());
 }
 
 #[test]
@@ -29,10 +37,7 @@ fn only_gmail_strips_dots_among_builtins() {
         "icloud.com",
         "mail.ru",
     ] {
-        assert!(
-            !reg.lookup(d).unwrap().strips_dots(),
-            "{d} must not strip dots"
-        );
+        assert!(!rule(&reg, d).strips_dots(), "{d} must not strip dots");
     }
 }
 
@@ -90,7 +95,7 @@ fn user_rule_takes_precedence_over_builtin() {
             .strip_dots(false)
             .lowercase_local(true),
     );
-    assert!(!reg.lookup("gmail.com").unwrap().strips_dots());
+    assert!(!rule(&reg, "gmail.com").strips_dots());
 }
 
 #[test]
@@ -101,10 +106,31 @@ fn custom_provider_added() {
             .subaddress_separator(Some('-'))
             .freemail(false),
     );
-    let r = reg.lookup("corp.example").expect("custom provider matches");
+    let r = rule(&reg, "corp.example");
     assert!(r.strips_dots());
     assert_eq!(r.separator(), Some('-'));
     assert!(!r.is_freemail());
+}
+
+#[test]
+fn custom_rule_is_not_freemail_by_default() {
+    // A normalization-only custom rule must not be reported as freemail.
+    let reg = ProviderRegistry::builtin().with(ProviderRule::new(["mail.corp.example"]));
+    assert!(!rule(&reg, "mail.corp.example").is_freemail());
+}
+
+#[test]
+fn idn_rule_matches_unicode_and_punycode() {
+    // A rule registered in Unicode matches both spellings, and one registered in
+    // punycode matches the Unicode spelling — IDNA canonicalization is consistent.
+    let uni = ProviderRegistry::empty().with(ProviderRule::new(["münchen.de"]).freemail(true));
+    assert!(uni.lookup("münchen.de").is_some());
+    assert!(uni.lookup("xn--mnchen-3ya.de").is_some());
+
+    let puny =
+        ProviderRegistry::empty().with(ProviderRule::new(["xn--mnchen-3ya.de"]).freemail(true));
+    assert!(puny.lookup("münchen.de").is_some());
+    assert!(puny.lookup("xn--mnchen-3ya.de").is_some());
 }
 
 #[test]

--- a/src/provider/tests.rs
+++ b/src/provider/tests.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+#[test]
+fn builtin_gmail_rule() {
+    let reg = ProviderRegistry::builtin();
+    let g = reg.lookup("gmail.com").expect("gmail is a known provider");
+    assert!(g.strips_dots(), "gmail ignores dots");
+    assert!(g.folds_case());
+    assert_eq!(g.separator(), Some('+'));
+    assert!(g.is_freemail());
+    // Alias resolves to the same rule.
+    assert!(reg.lookup("googlemail.com").unwrap().strips_dots());
+}
+
+#[test]
+fn builtin_lookup_is_case_insensitive() {
+    let reg = ProviderRegistry::builtin();
+    assert!(reg.lookup("GMAIL.COM").is_some());
+    assert!(reg.lookup("Yahoo.Com").is_some());
+}
+
+#[test]
+fn only_gmail_strips_dots_among_builtins() {
+    let reg = ProviderRegistry::builtin();
+    for d in [
+        "outlook.com",
+        "yahoo.com",
+        "proton.me",
+        "icloud.com",
+        "mail.ru",
+    ] {
+        assert!(
+            !reg.lookup(d).unwrap().strips_dots(),
+            "{d} must not strip dots"
+        );
+    }
+}
+
+#[test]
+fn builtin_freemail_coverage() {
+    // Every domain the legacy hardcoded list recognized must still be freemail.
+    let reg = ProviderRegistry::builtin();
+    for d in [
+        "gmail.com",
+        "googlemail.com",
+        "yahoo.com",
+        "yahoo.co.uk",
+        "yahoo.co.jp",
+        "outlook.com",
+        "hotmail.com",
+        "live.com",
+        "msn.com",
+        "aol.com",
+        "protonmail.com",
+        "proton.me",
+        "icloud.com",
+        "me.com",
+        "mac.com",
+        "mail.com",
+        "zoho.com",
+        "yandex.ru",
+        "yandex.com",
+        "mail.ru",
+        "gmx.com",
+        "gmx.de",
+        "web.de",
+        "tutanota.com",
+        "tuta.io",
+        "fastmail.com",
+    ] {
+        assert!(
+            reg.lookup(d).is_some_and(ProviderRule::is_freemail),
+            "{d} must be a known freemail provider"
+        );
+    }
+}
+
+#[test]
+fn unknown_domain_has_no_rule() {
+    let reg = ProviderRegistry::builtin();
+    assert!(reg.lookup("example.com").is_none());
+    assert!(reg.lookup("company.org").is_none());
+}
+
+#[test]
+fn user_rule_takes_precedence_over_builtin() {
+    // Re-define gmail to NOT strip dots; the user rule must win.
+    let reg = ProviderRegistry::builtin().with(
+        ProviderRule::new(["gmail.com"])
+            .strip_dots(false)
+            .lowercase_local(true),
+    );
+    assert!(!reg.lookup("gmail.com").unwrap().strips_dots());
+}
+
+#[test]
+fn custom_provider_added() {
+    let reg = ProviderRegistry::builtin().with(
+        ProviderRule::new(["corp.example"])
+            .strip_dots(true)
+            .subaddress_separator(Some('-'))
+            .freemail(false),
+    );
+    let r = reg.lookup("corp.example").expect("custom provider matches");
+    assert!(r.strips_dots());
+    assert_eq!(r.separator(), Some('-'));
+    assert!(!r.is_freemail());
+}
+
+#[test]
+fn rule_no_subaddressing() {
+    let r = ProviderRule::new(["x.example"]).subaddress_separator(None);
+    assert_eq!(r.separator(), None);
+}
+
+#[test]
+fn empty_registry_matches_nothing() {
+    assert!(ProviderRegistry::empty().lookup("gmail.com").is_none());
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded `is_gmail_domain()` and `is_freemail_domain()` lists with an extensible `ProviderRegistry` of `ProviderRule`s (Closes #5).

Each provider rule carries: domains, dot-stripping, case folding, subaddress separator, freemail flag. Applications can register their own.

## API

- **`ProviderRule::new(domains)`** + builder setters: `.strip_dots()`, `.lowercase_local()`, `.subaddress_separator(Option<char>)`, `.freemail()`.
- **`ProviderRegistry`** — `builtin()` / `empty()` / `add()` / `with()` / `lookup()`. Default = built-ins. User rules take precedence over built-ins (can redefine a built-in).
- **`Config::builder()`** — new `.provider_aware()`, `.add_provider(rule)`, `.providers(registry)`.

## Behavior

- **`provider_aware()` (opt-in):** when the domain matches a registered provider, that rule's dot/case/separator govern the address instead of the global policies. Non-matching domains keep the global policies. No surprise auto-normalization when off.
- **`is_freemail()`** now reads the registry (built-ins + custom), **always** — independent of `provider_aware`. Covers every domain the old hardcoded list recognized (verified by test).
- **`DotPolicy::GmailOnly`** consults only the **built-in** registry (Gmail/Googlemail) — custom providers added via `add_provider()` never affect this legacy mode; they apply only under `provider_aware()`. The built-in set lives in a process-wide `LazyLock`, so this hot path borrows it without a per-call allocation (matters for batch parsing).
- **Quoted local-parts are literal:** provider case-folding (and dots/subaddress) are skipped inside a quoted string; only a global lowercase policy still applies.

Built-in providers: Gmail/Googlemail (dot-stripping), Outlook/Hotmail/Live/MSN, Yahoo, ProtonMail, iCloud, Yandex, Mail.ru, plus AOL/Mail.com/Zoho/GMX/Web.de/Tutanota/Fastmail (freemail-only).

## Correctness fixes (caught in review)

- **GmailOnly leak:** custom `strip_dots` rules from `add_provider()` no longer leak into `DotPolicy::GmailOnly` when `provider_aware()` is off (regression test + fix).
- **Quoted-local case folding:** `"A.B"@gmail.com` under `provider_aware()` no longer folds to `a.b` (provider folding gated to unquoted locals; regression test + fix).
- IDN lookup path covered for Unicode NFC (decomposed vs composed) and confusable non-match.

## CI / tooling

- `structured-public-domains` is excluded from Dependabot — it is owned exclusively by the PSL data cascade (`psl-cascade.yml`), which cuts an off-tag data-only release. A Dependabot bump on main HEAD would route a PSL data update through the code path and race the cascade.

## Public API note

No removals — additive only. `DotPolicy::GmailOnly`, `dots_gmail_only()`, etc. all preserved (semver-friendly on the published 0.0.x crate).

## Testing

- `cargo nextest run --all-features` → 135 passed
- `cargo nextest run --no-default-features` → clean
- `cargo test --doc --all-features` → 6 passed
- `cargo clippy --all-features` and `--no-default-features` with `-D warnings` → clean
- `cargo fmt --all -- --check` → clean
- README updated with a Provider-Aware Normalization section.

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional provider-aware email normalization with a configurable provider registry (local-part case folding, dot stripping, and subaddress/tag separators).
  * Provider rules can be customized and override built-in behavior.
* **Documentation**
  * Updated README with a “Provider-Aware Normalization” section, including configuration examples and freemail/provider-specific normalization details.
* **Bug Fixes**
  * Freemail detection is now derived from the matched provider rule during parsing (no fixed allowlist).
* **Tests**
  * Expanded coverage for Gmail/Googlemail behavior, provider overrides, IDN/punycode matching, and quoted local-part handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
