### PR TITLE
ci(release-plz): gate releases on code commits, not data bumps

### DIFF
--- a/.github/workflows/psl-cascade.yml
+++ b/.github/workflows/psl-cascade.yml
@@ -236,7 +236,7 @@ jobs:
           PY
 
           git add -A
-          git commit -m "feat(data): bump PSL data to structured-public-domains v${VERSION}"
+          git commit -m "chore(data): bump PSL data to structured-public-domains v${VERSION}"
 
           # Attach the token to origin now (checkout used persist-credentials:
           # false), after the untrusted cargo steps have already run.
@@ -318,7 +318,7 @@ jobs:
           # code release's changelog lists only the code — not the data again.
           # Tolerate an already-open PR from a prior partial run.
           gh pr create --base main --head "$BRANCH" \
-            --title "feat(data): bump PSL data to structured-public-domains v${VERSION}" \
+            --title "chore(data): bump PSL data to structured-public-domains v${VERSION}" \
             --body-file /tmp/sync-notes.md \
             || true
           # GitHub computes mergeability asynchronously after `gh pr create`, so

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -14,6 +14,10 @@ commit_parsers = [
     { message = "^docs\\(ci\\)", skip = true },
     { message = "^Merge", skip = true },
     { message = "^docs", group = "Documentation" },
+    # PSL data bumps are released off-tag by the cascade (psl-cascade.yml), which
+    # writes their CHANGELOG entry itself. Skip them here so release-plz never
+    # opens an empty duplicate code release for an already-published data bump.
+    { message = "^feat\\(data\\)", skip = true },
     { message = "^feat", group = "Added" },
     { message = "^fix", group = "Fixed" },
     { message = "^perf", group = "Performance" },

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -4,6 +4,12 @@ git_release_enable = true
 changelog_update = true
 git_tag_name = "v{{ version }}"
 publish = false
+# Only open a release PR when a real code change is present. commit_parsers
+# below only control the changelog TEXT — they do NOT stop release-plz from
+# bumping on a package-file change. The PSL cascade syncs its data bumps as
+# `chore(data)` (released off-tag, not by release-plz), so gating on these
+# code types keeps release-plz from opening empty duplicate releases for them.
+release_commits = "^(feat|fix|perf|refactor|docs|test)"
 
 [changelog]
 commit_parsers = [
@@ -14,10 +20,6 @@ commit_parsers = [
     { message = "^docs\\(ci\\)", skip = true },
     { message = "^Merge", skip = true },
     { message = "^docs", group = "Documentation" },
-    # PSL data bumps are released off-tag by the cascade (psl-cascade.yml), which
-    # writes their CHANGELOG entry itself. Skip them here so release-plz never
-    # opens an empty duplicate code release for an already-published data bump.
-    { message = "^feat\\(data\\)", skip = true },
     { message = "^feat", group = "Added" },
     { message = "^fix", group = "Fixed" },
     { message = "^perf", group = "Performance" },


### PR DESCRIPTION
## Summary

release-plz was opening empty duplicate code-release PRs (e.g. #67) for PSL data bumps that are already published off-tag by the cascade.

Root cause (confirmed against release-plz docs): `[changelog] commit_parsers` `skip` only hides a commit from the changelog **text** — it does NOT stop release-plz from bumping the version when package files change. So skipping the data commit in commit_parsers (the first attempt) would not have suppressed the empty release.

## Fix

- **`.release-plz.toml`**: add `release_commits = "^(feat|fix|perf|refactor|docs|test)"` so release-plz opens a release PR only when a genuine code commit is present.
- **`psl-cascade.yml`**: emit the data sync commit / sync-PR title as `chore(data): ...` (a dependency bump is a chore) so it does not match `release_commits` and never triggers a release-plz PR. Data releases remain fully handled off-tag by the cascade, which writes its own CHANGELOG entry.

Gating is by commit **type**, not scope, so a genuine `feat(...)` code change still releases normally (addresses the 'data scope hides code features' concern).

## Effect

- No empty/duplicate release PRs from data syncs
- After merge, release-plz recomputes and drops the stale #67
- Genuine code changes still produce a release PR

Closes #69